### PR TITLE
docs: post-v0.2.0 audit fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ internal/app/        CLI flag parsing, app composition, ctx setup
 internal/azure/      PIM REST client (client/roles/activation/discovery), errors, scopes, duration
 internal/state/      TOML config + state with mutex-guarded Store
 internal/headless/   non-TUI execution path for --headless
+internal/completion/ shell completion script generators (bash/zsh/fish)
 internal/tui/        Bubble Tea screens
   activate/          4-step wizard
   dashboard/         home screen + favorites

--- a/README.md
+++ b/README.md
@@ -60,21 +60,33 @@ pim activate \
 ### 🤖 Headless mode (scripting / CI)
 
 ```sh
-# Activate — all four flags required
+# Activate — only --role is required; --time defaults to 1h, --scope to the
+# eligibility scope, --justification may be empty
 pim activate --headless \
   --role Reader \
   --scope /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
   --time 1h \
   --justification "Deploy pipeline"
 
-# Deactivate matching assignments
+# Deactivate matching assignments (--role/--scope or --yes required to avoid
+# accidentally deactivating everything; inherited group assignments are skipped)
 pim deactivate --headless --role Reader
 
 # Status — JSON output
 pim status --headless --output json
 ```
 
-Exit code `0` on success, `1` on error.
+Exit code `0` on success, `1` on error, `130` on user cancel (Ctrl-C).
+
+#### Matching policy for `--role` and `--scope`
+
+Both flags resolve in two passes:
+
+1. **Exact match** wins. `--scope my-rg` matches `my-rg` even if `my-rg-dev` also exists.
+2. **Substring fallback** if no exact match. `--role admin` matches anything containing "admin".
+3. **Ambiguity errors out.** If multiple values match by substring with no exact match, the command exits non-zero and lists the candidates instead of silently picking one.
+
+ARM scope paths (`/subscriptions/...`) take precedence over display-name matching.
 
 ## 🐚 Shell completions
 
@@ -161,8 +173,8 @@ task clean    # remove build artefacts
 ## 📤 Release
 
 ```sh
-git tag v2.0.0
-git push origin v2.0.0
+git tag vX.Y.Z
+git push origin vX.Y.Z
 ```
 
 GoReleaser builds cross-platform archives (linux, darwin, windows — amd64 + arm64) and attaches them to the GitHub release automatically.


### PR DESCRIPTION
Audit-driven cleanup after v0.2.0 release.

- README: headless `activate` only requires `--role` (was claiming all four)
- README: new "Matching policy" subsection — exact-first then substring, ambiguity errors out. Closes the user-facing gap from #14
- README: document exit code `130`, `--yes` for blanket deactivate, inherited-assignment skip
- README: release example uses `vX.Y.Z` placeholder (was misleading `v2.0.0`)
- AGENTS.md: layout tree now lists `internal/completion/`