### PR TITLE
fix: skip permanent assignments in deactivate

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ pim activate --headless \
   --justification "Deploy pipeline"
 
 # Deactivate matching assignments (--role/--scope or --yes required to avoid
-# accidentally deactivating everything; inherited group assignments are skipped)
+# accidentally deactivating everything; permanent and inherited assignments
+# are skipped because they cannot be deactivated via PIM)
 pim deactivate --headless --role Reader
 
 # Status — JSON output

--- a/internal/headless/headless_test.go
+++ b/internal/headless/headless_test.go
@@ -2,6 +2,7 @@ package headless
 
 import (
 	"testing"
+	"time"
 
 	"github.com/jeircul/pim/internal/azure"
 )
@@ -206,4 +207,34 @@ func TestMatchBest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPartitionDeactivatable(t *testing.T) {
+	exp := time.Now().Add(time.Hour).Format(time.RFC3339)
+	assignments := []azure.ActiveAssignment{
+		{RoleName: "direct", MemberType: "Direct", EndDateTime: exp},
+		{RoleName: "inherited", MemberType: "Inherited", EndDateTime: exp},
+		{RoleName: "permanent-direct", MemberType: "Direct", EndDateTime: ""},
+		{RoleName: "permanent-inherited", MemberType: "Inherited", EndDateTime: ""},
+	}
+
+	deact, inh, perm := partitionDeactivatable(assignments)
+
+	if len(deact) != 1 || deact[0].RoleName != "direct" {
+		t.Errorf("deactivatable = %v, want [direct]", roleNames(deact))
+	}
+	if len(inh) != 2 {
+		t.Errorf("inherited count = %d, want 2 (inherited + permanent-inherited)", len(inh))
+	}
+	if len(perm) != 1 || perm[0].RoleName != "permanent-direct" {
+		t.Errorf("permanent = %v, want [permanent-direct]", roleNames(perm))
+	}
+}
+
+func roleNames(a []azure.ActiveAssignment) []string {
+	out := make([]string, len(a))
+	for i, x := range a {
+		out[i] = x.RoleName
+	}
+	return out
 }

--- a/internal/headless/run.go
+++ b/internal/headless/run.go
@@ -78,10 +78,14 @@ func runDeactivate(ctx context.Context, a *app.App, client ClientAPI, user *azur
 		return fmt.Errorf("get active assignments: %w", err)
 	}
 
-	all, inherited := partitionInherited(assignments)
+	all, inherited, permanent := partitionDeactivatable(assignments)
 	for _, inh := range inherited {
 		fmt.Fprintf(os.Stderr, "skipping inherited assignment: %s @ %s (cannot self-deactivate group-inherited roles)\n",
 			inh.RoleName, inh.ScopeDisplay)
+	}
+	for _, p := range permanent {
+		fmt.Fprintf(os.Stderr, "skipping permanent assignment: %s @ %s (no expiry; not PIM-activated)\n",
+			p.RoleName, p.ScopeDisplay)
 	}
 
 	targets, err := filterAssignments(all, a.Config.Roles, a.Config.Scopes)
@@ -377,16 +381,21 @@ func matchBest(s string, filters []string) (bool, error) {
 	return true, nil
 }
 
-// partitionInherited splits assignments into direct and inherited.
-func partitionInherited(assignments []azure.ActiveAssignment) (direct, inherited []azure.ActiveAssignment) {
+// partitionDeactivatable splits assignments into ones safe to deactivate
+// versus ones that should be skipped: inherited (group membership, cannot
+// self-deactivate) and permanent (no expiry, not PIM-activated).
+func partitionDeactivatable(assignments []azure.ActiveAssignment) (deactivatable, inherited, permanent []azure.ActiveAssignment) {
 	for _, a := range assignments {
-		if strings.EqualFold(a.MemberType, "Inherited") {
+		switch {
+		case strings.EqualFold(a.MemberType, "Inherited"):
 			inherited = append(inherited, a)
-		} else {
-			direct = append(direct, a)
+		case a.IsPermanent():
+			permanent = append(permanent, a)
+		default:
+			deactivatable = append(deactivatable, a)
 		}
 	}
-	return direct, inherited
+	return deactivatable, inherited, permanent
 }
 
 func jsonOut(v any, out io.Writer) error {

--- a/internal/headless/run_test.go
+++ b/internal/headless/run_test.go
@@ -167,6 +167,7 @@ func TestRunDeactivate(t *testing.T) {
 		Scope:            "/subscriptions/sub-1",
 		ScopeDisplay:     "My Sub",
 		RoleDefinitionID: "rd-1",
+		EndDateTime:      "2099-01-01T00:00:00Z",
 	}
 
 	tests := []struct {
@@ -242,6 +243,7 @@ func TestRunDeactivateYesFlag(t *testing.T) {
 		Scope:            "/subscriptions/sub-1",
 		ScopeDisplay:     "My Sub",
 		RoleDefinitionID: "rd-1",
+		EndDateTime:      "2099-01-01T00:00:00Z",
 	}
 
 	a := newTestApp(t, app.Config{

--- a/internal/tui/deactivate/deactivate.go
+++ b/internal/tui/deactivate/deactivate.go
@@ -58,6 +58,7 @@ type Model struct {
 	keys        styles.KeyMap
 	spinner     components.Spinner
 	items       []deactItem
+	skipped     int // permanent + inherited assignments hidden from the list
 	cursor      int
 	step        deactStep
 	loading     bool
@@ -114,9 +115,14 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case loadMsg:
 		m.loading = false
 		m.err = msg.err
-		m.items = make([]deactItem, len(msg.active))
-		for i, a := range msg.active {
-			m.items[i] = deactItem{assignment: a}
+		m.items = m.items[:0]
+		m.skipped = 0
+		for _, a := range msg.active {
+			if strings.EqualFold(a.MemberType, "Inherited") || a.IsPermanent() {
+				m.skipped++
+				continue
+			}
+			m.items = append(m.items, deactItem{assignment: a})
 		}
 		m.cursor = 0
 
@@ -250,7 +256,11 @@ func (m Model) View() string {
 		return sb.String()
 	}
 	if len(m.items) == 0 {
-		sb.WriteString(m.theme.Subtle.Render("no active elevations to deactivate") + "\n")
+		msg := "no active elevations to deactivate"
+		if m.skipped > 0 {
+			msg = fmt.Sprintf("no deactivatable elevations (%d permanent or inherited assignment(s) hidden)", m.skipped)
+		}
+		sb.WriteString(m.theme.Subtle.Render(msg) + "\n")
 		hints := []key.Binding{m.keys.Back}
 		sb.WriteString(components.RenderStatusBar(m.theme.HelpKey, m.theme.HelpDesc, m.theme.Subtle, hints, ""))
 		return sb.String()
@@ -259,6 +269,9 @@ func (m Model) View() string {
 	switch m.step {
 	case stepSelect:
 		sb.WriteString(m.theme.Title.Render("Select roles to deactivate:") + "\n\n")
+		if m.skipped > 0 {
+			sb.WriteString(m.theme.Subtle.Render(fmt.Sprintf("(%d permanent or inherited assignment(s) hidden)", m.skipped)) + "\n\n")
+		}
 		for i, it := range m.items {
 			cur := "  "
 			if i == m.cursor {


### PR DESCRIPTION
Permanent assignments (no expiry, not PIM-activated) cannot be deactivated via the PIM API. Showing them in the deactivate list was misleading and attempting to deactivate them returned errors.

## Behavior change

- **TUI deactivate**: permanent + inherited assignments are filtered out at load time. A subtitle shows the hidden count so users understand what's missing.
- **Headless deactivate**: permanent assignments produce a stderr skip note, matching the existing inherited-skip pattern.
- **Status screens (TUI + headless)**: unchanged. Permanent assignments are still shown — status is informational, not actionable.

## Implementation

- `partitionInherited` → `partitionDeactivatable` returning `(deactivatable, inherited, permanent)`
- New test `TestPartitionDeactivatable` covers all four direct/inherited × time-bound/permanent classifications
- README headless example updated

## Verification

`task fmt && task test && task build` green.