### PR TITLE
fix: zsh completion registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,14 @@ ARM scope paths (`/subscriptions/...`) take precedence over display-name matchin
 # bash — add to ~/.bashrc
 source <(pim completion bash)
 
-# zsh — add to ~/.zshrc
+# zsh (simple) — add to ~/.zshrc
 source <(pim completion zsh)
+
+# zsh (fpath) — run once, then add the two lines below to ~/.zshrc
+mkdir -p ~/.zfunc
+pim completion zsh > ~/.zfunc/_pim
+# fpath=(~/.zfunc $fpath)
+# autoload -Uz compinit && compinit
 
 # fish
 pim completion fish > ~/.config/fish/completions/pim.fish

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -78,7 +78,7 @@ _pim() {
     esac
 }
 
-_pim
+compdef _pim pim
 `)
 }
 


### PR DESCRIPTION
## Bug

`source <(pim completion zsh)` was a no-op. The script ended with a bare `_pim` call which runs the function once at source time instead of registering it as a completion handler. Zsh requires `compdef _pim pim` for the `source <(...))` pattern.

## Fix

- Last line of the zsh script: `_pim` → `compdef _pim pim`
- README: documents both the simple `source <(...)` path and the `fpath` alternative

## Verify

```zsh
source <(pim completion zsh)
pim <TAB>   # now shows: activate deactivate status completion version help
```