### PR TITLE
fix: favorites scope display-name matching + CI go mod download

### DIFF
--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -35,6 +35,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: Download modules
+        run: go mod download
+
       - name: Run tests
         id: run-tests
         continue-on-error: true

--- a/internal/tui/activate/wizard.go
+++ b/internal/tui/activate/wizard.go
@@ -283,13 +283,23 @@ func (w Wizard) advanceFromRoles() (Wizard, tea.Cmd) {
 	return w.startOptions()
 }
 
-// scopeOverride returns the first --scope flag value that is a child of (or equal to)
-// r.Scope, enabling scoped-down activation for MG/subscription-eligible roles.
+// scopeOverride returns the target scope to use when a --scope filter matches
+// the role's eligibility scope. Returns the filter value when it is a valid
+// ARM child path, or the role's own scope when the filter matches by display
+// name substring. Returns "" when no filter matches.
 func (w Wizard) scopeOverride(r azure.Role) string {
 	for _, s := range w.deps.ScopeFilter {
 		s = strings.TrimSpace(s)
-		if s != "" && azure.ScopeIsChildOf(s, r.Scope) {
+		if s == "" {
+			continue
+		}
+		if azure.ScopeIsChildOf(s, r.Scope) {
 			return s
+		}
+		lower := strings.ToLower(s)
+		if strings.Contains(strings.ToLower(r.ScopeDisplay), lower) ||
+			strings.Contains(strings.ToLower(r.Scope), lower) {
+			return r.Scope
 		}
 	}
 	return ""


### PR DESCRIPTION
Two fixes in one PR.

## 1. Favorites scope matching

Favorites with a display-name scope (e.g. `scope = "q901"`) were falling through to the interactive scope tree instead of auto-selecting. Root cause: `scopeOverride` only checked ARM path child relationships (`ScopeIsChildOf`), so a display name never matched.

Fix: after the ARM check, also try case-insensitive substring match against the role's `ScopeDisplay` and `Scope` fields. When matched by display name, returns the role's own ARM scope (the eligibility scope itself) so activation proceeds without the scope tree.

Favorites with a full ARM path scope continue to work as before.

## 2. CI go mod download

The batch Renovate dep bump (#41) updated `go.mod` but `go.sum` could not be updated locally due to a TLS proxy cert issue in the dev environment. Added a `go mod download` step to the CI workflow so the sum entries are populated before `go test` runs.