### PR TITLE
fix(ci): go mod tidy before tests

### DIFF
--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -35,8 +35,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Download modules
-        run: go mod download
+      - name: Tidy modules
+        run: go mod tidy
 
       - name: Run tests
         id: run-tests


### PR DESCRIPTION
go mod download does not write go.sum entries. Replace with go mod tidy which both downloads and updates go.sum.