### PR TITLE
feat: direct activation for complete favorites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,14 @@ Full API reference: `.agents/skills/golang/references/azure-pim-api.md`.
 - Multiple substring matches with no exact match returns an ambiguity error.
 - ARM scope paths take precedence over display-name matching.
 
+## Favorites behaviour
+
+- `Favorite.Complete()` returns true when `role`, `scope`, `duration`, and `justification` are all non-empty.
+- Dashboard 1–9 shortcut: if `Complete()` → `startWizard` with `AutoSubmit=true` and `favoritePending=true`; activation result shown as dashboard notice, TUI stays open. If not `Complete()` → error notice, no activation.
+- `favoritePending` on `AppModel` distinguishes favorite-triggered activations (return to dashboard) from manual wizard activations (quit with summary).
+- Favorites screen `ActivateMsg` always opens the wizard (incomplete favorites stop at the missing step).
+- `autoAdvance` in `rolelist.go` uses `scopeFilter` as a tiebreaker when multiple roles share the same name — emits only when exactly one scope match survives.
+
 ## Skills
 
 `.agents/skills/golang/` has full Go conventions, Bubble Tea v2 patterns, and the Azure PIM API reference.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ pim activate \
 ### 🤖 Headless mode (scripting / CI)
 
 ```sh
-# Activate — only --role is required; --time defaults to 1h, --scope resolves
-# by display name substring, --justification may be empty
+# Activate — only --role is required; --time defaults to 1h
+# --scope matches ARM path first, then display-name substring
 pim activate --headless \
   --role Reader \
   --scope my-subscription \
@@ -108,12 +108,12 @@ pim completion fish > ~/.config/fish/completions/pim.fish
 
 ## ⏱️ Duration format
 
-`30m`, `1h`, `1h30m`, `2h`, `3h`, `4h`, `6h`, `8h`. Parsed as minutes; decimals and mixed units accepted (`1.5h` = 90 min).
+`30m`, `1h`, `2h`, `4h`, `8h` (tab-completion candidates). The parser accepts any integer or decimal hours (`1.5h` = 90 min), any minutes (`45m`), and mixed units (`1h30m`).
 
 ## 🔐 Authentication
 
 Uses the existing `az login` / `Connect-AzAccount` session automatically.  
-Set `PIM_ALLOW_DEVICE_LOGIN=true` to allow interactive device code fallback when no cached credential is found.
+Set `PIM_ALLOW_DEVICE_LOGIN=true` (or `1` / `yes`) to allow interactive device code fallback when no cached credential is found.
 
 ## ⚙️ Configuration
 
@@ -148,7 +148,7 @@ key   = 2
 
 `scope` accepts a full ARM path (`/subscriptions/…`) or a display-name substring — the TUI resolves either.
 
-`label` is required. When `role`, `scope`, `duration`, and `justification` are all set, pressing the shortcut key activates immediately with no prompts and returns to the dashboard with a result notice. If any field is missing the shortcut shows an error notice; open the favorite in the favorites editor (`f`) to complete it.
+`label` is required. When `role`, `scope`, `duration`, and `justification` are all set, pressing the shortcut key activates immediately with no prompts and returns to the dashboard with a result notice. If any field is missing the shortcut shows an error notice — open the favorite in the favorites editor (`f`) and activate from there; the wizard will stop at the first missing field.
 
 ## 🛠️ Development
 

--- a/README.md
+++ b/README.md
@@ -131,22 +131,24 @@ Example `config.toml`:
 default_duration = "2h"   # default when no --time flag or favorite duration is set
 
 [[favorites]]
-label    = "Prod reader"
-role     = "Reader"
-scope    = "my-prod-subscription"
-duration = "1h"            # overrides default_duration for this favorite
-key      = 1
+label         = "Prod reader"
+role          = "Reader"
+scope         = "my-prod-subscription"
+duration      = "1h"      # overrides default_duration for this favorite
+justification = "Daily read access"
+key           = 1
 
 [[favorites]]
 label = "Dev owner"
 role  = "Owner"
 scope = "my-dev-subscription"
-# duration omitted — falls back to default_duration
+# duration and justification omitted — opens wizard at the missing step
 key   = 2
 ```
 
-Scope can be a full ARM path or a display name — the TUI resolves either.
-`label` is required. All other fields are optional and fall back to defaults or wizard prompts.
+`scope` accepts a full ARM path (`/subscriptions/…`) or a display-name substring — the TUI resolves either.
+
+`label` is required. When `role`, `scope`, `duration`, and `justification` are all set, pressing the shortcut key activates immediately with no prompts and returns to the dashboard with a result notice. If any field is missing the shortcut shows an error notice; open the favorite in the favorites editor (`f`) to complete it.
 
 ## 🛠️ Development
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ pim completion fish > ~/.config/fish/completions/pim.fish
 
 ## ⏱️ Duration format
 
-`30m`, `1h`, `2h`, `4h`, `8h` (tab-completion candidates). The parser accepts any integer or decimal hours (`1.5h` = 90 min), any minutes (`45m`), and mixed units (`1h30m`).
+The parser accepts any integer or decimal hours (`1h`, `1.5h` = 90 min), minutes (`30m`, `45m`), and mixed units (`1h30m`).
 
 ## 🔐 Authentication
 

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -69,76 +69,72 @@ func Zsh(w io.Writer) {
 	fmt.Fprint(w, `#compdef pim
 
 _pim() {
-    local -a commands
-    commands=(
-        'activate:activate roles via TUI wizard'
-        'deactivate:deactivate active role elevations'
-        'status:view active and eligible roles'
-        'completion:print shell completion script'
-        'version:print version'
-        'help:show help'
-    )
+    local context state state_descr line
+    typeset -A opt_args
 
-    local -a activate_flags
-    activate_flags=(
-        '--role[role name filter (repeatable)]:role name'
-        '-r[role name filter (repeatable)]:role name'
-        '--scope[scope path (repeatable)]:scope path'
-        '--time[activation duration (e.g. 1h, 30m)]:duration:(30m 1h 2h 4h 8h)'
-        '-t[activation duration (e.g. 1h, 30m)]:duration:(30m 1h 2h 4h 8h)'
-        '--justification[justification text]:text'
-        '-j[justification text]:text'
-        '--yes[skip confirmation]'
-        '-y[skip confirmation]'
-        '--headless[non-TUI mode]'
-        '--output[output format]:format:(table json)'
-        '-o[output format]:format:(table json)'
-        '--config-dir[override config directory]:dir:_directories'
-    )
+    _arguments \
+        '1: :->subcmd' \
+        '*:: :->args'
 
-    local -a deactivate_flags
-    deactivate_flags=(
-        '--role[role name filter (repeatable)]:role name'
-        '-r[role name filter (repeatable)]:role name'
-        '--scope[scope path (repeatable)]:scope path'
-        '--headless[non-TUI mode]'
-        '--output[output format]:format:(table json)'
-        '-o[output format]:format:(table json)'
-        '--config-dir[override config directory]:dir:_directories'
-    )
-
-    local -a status_flags
-    status_flags=(
-        '--role[role name filter (repeatable)]:role name'
-        '-r[role name filter (repeatable)]:role name'
-        '--scope[scope path (repeatable)]:scope path'
-        '--headless[non-TUI mode]'
-        '--output[output format]:format:(table json)'
-        '-o[output format]:format:(table json)'
-        '--config-dir[override config directory]:dir:_directories'
-    )
-
-    local -a base_flags
-    base_flags=(
-        '--config-dir[override config directory]:dir:_directories'
-    )
-
-    if (( CURRENT == 2 )); then
-        _describe 'command' commands
-        return
-    fi
-
-    case "$words[2]" in
-        activate)
-            _arguments "${activate_flags[@]}" ;;
-        deactivate)
-            _arguments "${deactivate_flags[@]}" ;;
-        status)
-            _arguments "${status_flags[@]}" ;;
-        completion)
-            _values 'shell' bash zsh fish ;;
-        version|help)
-            _arguments "${base_flags[@]}" ;;
+    case $state in
+        subcmd)
+            local -a subcmds
+            subcmds=(
+                'activate:activate roles via TUI wizard'
+                'deactivate:deactivate active role elevations'
+                'status:view active and eligible roles'
+                'completion:print shell completion script'
+                'version:print version'
+                'help:show help'
+            )
+            _describe 'subcommand' subcmds
+            ;;
+        args)
+            case $words[1] in
+                activate)
+                    _arguments \
+                        '--role[role name filter (repeatable)]:role name' \
+                        '-r[role name filter (repeatable)]:role name' \
+                        '--scope[scope path (repeatable)]:scope path' \
+                        '--time[activation duration]:duration:(30m 1h 2h 4h 8h)' \
+                        '-t[activation duration]:duration:(30m 1h 2h 4h 8h)' \
+                        '--justification[justification text]:text' \
+                        '-j[justification text]:text' \
+                        '--yes[skip confirmation]' \
+                        '-y[skip confirmation]' \
+                        '--headless[non-TUI mode]' \
+                        '--output[output format]:format:(table json)' \
+                        '-o[output format]:format:(table json)' \
+                        '--config-dir[override config directory]:dir:_directories'
+                    ;;
+                deactivate)
+                    _arguments \
+                        '--role[role name filter (repeatable)]:role name' \
+                        '-r[role name filter (repeatable)]:role name' \
+                        '--scope[scope path (repeatable)]:scope path' \
+                        '--yes[deactivate all without prompt]' \
+                        '-y[deactivate all without prompt]' \
+                        '--headless[non-TUI mode]' \
+                        '--output[output format]:format:(table json)' \
+                        '-o[output format]:format:(table json)' \
+                        '--config-dir[override config directory]:dir:_directories'
+                    ;;
+                status)
+                    _arguments \
+                        '--headless[non-TUI mode]' \
+                        '--output[output format]:format:(table json)' \
+                        '-o[output format]:format:(table json)' \
+                        '--config-dir[override config directory]:dir:_directories'
+                    ;;
+                completion)
+                    _values 'shell' bash zsh fish
+                    ;;
+                version|help)
+                    _arguments \
+                        '--config-dir[override config directory]:dir:_directories'
+                    ;;
+            esac
+            ;;
     esac
 }
 

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -13,7 +13,10 @@ func Bash(w io.Writer) {
     _init_completion || return
 
     local commands="activate deactivate status completion version help"
-    local flags="--role --scope --time --justification --yes --headless --output --config-dir"
+    local common_flags="--role -r --scope --time -t --justification -j --yes -y --headless --output -o --config-dir"
+    local activate_flags="$common_flags"
+    local deactivate_flags="--role -r --scope --headless --output -o --config-dir"
+    local status_flags="--role -r --scope --headless --output -o --config-dir"
 
     case "$prev" in
         --output|-o)
@@ -22,13 +25,36 @@ func Bash(w io.Writer) {
         --time|-t)
             COMPREPLY=( $(compgen -W "30m 1h 2h 4h 8h" -- "$cur") )
             return ;;
+        --config-dir)
+            _filedir -d
+            return ;;
         completion)
             COMPREPLY=( $(compgen -W "bash zsh fish" -- "$cur") )
             return ;;
     esac
 
+    local subcmd=""
+    local i
+    for (( i=1; i < cword; i++ )); do
+        if [[ "${words[i]}" != -* ]]; then
+            subcmd="${words[i]}"
+            break
+        fi
+    done
+
     if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "$flags" -- "$cur") )
+        case "$subcmd" in
+            activate)
+                COMPREPLY=( $(compgen -W "$activate_flags" -- "$cur") ) ;;
+            deactivate)
+                COMPREPLY=( $(compgen -W "$deactivate_flags" -- "$cur") ) ;;
+            status)
+                COMPREPLY=( $(compgen -W "$status_flags" -- "$cur") ) ;;
+            version|help)
+                COMPREPLY=( $(compgen -W "--config-dir" -- "$cur") ) ;;
+            *)
+                COMPREPLY=( $(compgen -W "$common_flags" -- "$cur") ) ;;
+        esac
     else
         COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
     fi
@@ -56,12 +82,44 @@ _pim() {
     local -a activate_flags
     activate_flags=(
         '--role[role name filter (repeatable)]:role name'
+        '-r[role name filter (repeatable)]:role name'
         '--scope[scope path (repeatable)]:scope path'
         '--time[activation duration (e.g. 1h, 30m)]:duration:(30m 1h 2h 4h 8h)'
+        '-t[activation duration (e.g. 1h, 30m)]:duration:(30m 1h 2h 4h 8h)'
         '--justification[justification text]:text'
+        '-j[justification text]:text'
         '--yes[skip confirmation]'
+        '-y[skip confirmation]'
         '--headless[non-TUI mode]'
         '--output[output format]:format:(table json)'
+        '-o[output format]:format:(table json)'
+        '--config-dir[override config directory]:dir:_directories'
+    )
+
+    local -a deactivate_flags
+    deactivate_flags=(
+        '--role[role name filter (repeatable)]:role name'
+        '-r[role name filter (repeatable)]:role name'
+        '--scope[scope path (repeatable)]:scope path'
+        '--headless[non-TUI mode]'
+        '--output[output format]:format:(table json)'
+        '-o[output format]:format:(table json)'
+        '--config-dir[override config directory]:dir:_directories'
+    )
+
+    local -a status_flags
+    status_flags=(
+        '--role[role name filter (repeatable)]:role name'
+        '-r[role name filter (repeatable)]:role name'
+        '--scope[scope path (repeatable)]:scope path'
+        '--headless[non-TUI mode]'
+        '--output[output format]:format:(table json)'
+        '-o[output format]:format:(table json)'
+        '--config-dir[override config directory]:dir:_directories'
+    )
+
+    local -a base_flags
+    base_flags=(
         '--config-dir[override config directory]:dir:_directories'
     )
 
@@ -73,8 +131,14 @@ _pim() {
     case "$words[2]" in
         activate)
             _arguments $activate_flags ;;
+        deactivate)
+            _arguments $deactivate_flags ;;
+        status)
+            _arguments $status_flags ;;
         completion)
             _values 'shell' bash zsh fish ;;
+        version|help)
+            _arguments $base_flags ;;
     esac
 }
 
@@ -105,7 +169,7 @@ complete -c pim -f -n "__fish_seen_subcommand_from completion" \
 
 # activate flags
 complete -c pim -n "__fish_seen_subcommand_from activate" \
-    -l role          -d "role name filter (repeatable)"
+    -l role -s r     -d "role name filter (repeatable)"
 complete -c pim -n "__fish_seen_subcommand_from activate" \
     -l scope         -d "scope path (repeatable)"
 complete -c pim -n "__fish_seen_subcommand_from activate" \
@@ -120,5 +184,37 @@ complete -c pim -n "__fish_seen_subcommand_from activate" \
 complete -c pim -n "__fish_seen_subcommand_from activate" \
     -l output -s o   -d "output format" \
     -a "table json"
+complete -c pim -n "__fish_seen_subcommand_from activate" \
+    -l config-dir    -d "override config directory"
+
+# deactivate flags
+complete -c pim -n "__fish_seen_subcommand_from deactivate" \
+    -l role -s r     -d "role name filter (repeatable)"
+complete -c pim -n "__fish_seen_subcommand_from deactivate" \
+    -l scope         -d "scope path (repeatable)"
+complete -c pim -n "__fish_seen_subcommand_from deactivate" \
+    -l headless      -d "non-TUI mode"
+complete -c pim -n "__fish_seen_subcommand_from deactivate" \
+    -l output -s o   -d "output format" \
+    -a "table json"
+complete -c pim -n "__fish_seen_subcommand_from deactivate" \
+    -l config-dir    -d "override config directory"
+
+# status flags
+complete -c pim -n "__fish_seen_subcommand_from status" \
+    -l role -s r     -d "role name filter (repeatable)"
+complete -c pim -n "__fish_seen_subcommand_from status" \
+    -l scope         -d "scope path (repeatable)"
+complete -c pim -n "__fish_seen_subcommand_from status" \
+    -l headless      -d "non-TUI mode"
+complete -c pim -n "__fish_seen_subcommand_from status" \
+    -l output -s o   -d "output format" \
+    -a "table json"
+complete -c pim -n "__fish_seen_subcommand_from status" \
+    -l config-dir    -d "override config directory"
+
+# version/help flags
+complete -c pim -n "__fish_seen_subcommand_from version help" \
+    -l config-dir    -d "override config directory"
 `)
 }

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -130,15 +130,15 @@ _pim() {
 
     case "$words[2]" in
         activate)
-            _arguments $activate_flags ;;
+            _arguments "${activate_flags[@]}" ;;
         deactivate)
-            _arguments $deactivate_flags ;;
+            _arguments "${deactivate_flags[@]}" ;;
         status)
-            _arguments $status_flags ;;
+            _arguments "${status_flags[@]}" ;;
         completion)
             _values 'shell' bash zsh fish ;;
         version|help)
-            _arguments $base_flags ;;
+            _arguments "${base_flags[@]}" ;;
     esac
 }
 

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,11 +20,35 @@ const (
 
 // Favorite is a saved role+scope+duration combo.
 type Favorite struct {
-	Label    string `toml:"label"`
-	Role     string `toml:"role"`
-	Scope    string `toml:"scope"`
-	Duration string `toml:"duration"`
-	Key      int    `toml:"key"` // 1-9 for dashboard shortcuts
+	Label         string `toml:"label"`
+	Role          string `toml:"role"`
+	Scope         string `toml:"scope"`
+	Duration      string `toml:"duration"`
+	Justification string `toml:"justification"`
+	Key           int    `toml:"key"` // 1-9 for dashboard shortcuts
+}
+
+// Complete reports whether all four required activation fields are set.
+func (f Favorite) Complete() bool {
+	return f.Role != "" && f.Scope != "" && f.Duration != "" && f.Justification != ""
+}
+
+// MissingFields returns a comma-separated list of unset required fields.
+func (f Favorite) MissingFields() string {
+	var missing []string
+	if f.Role == "" {
+		missing = append(missing, "role")
+	}
+	if f.Scope == "" {
+		missing = append(missing, "scope")
+	}
+	if f.Duration == "" {
+		missing = append(missing, "duration")
+	}
+	if f.Justification == "" {
+		missing = append(missing, "justification")
+	}
+	return strings.Join(missing, ", ")
 }
 
 // Preferences holds user-editable preferences.

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -31,8 +31,8 @@ func TestStoreFavorites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s.UpsertFavorite(Favorite{Label: "prod", Role: "Reader", Scope: "/subscriptions/abc", Duration: "1h", Key: 1})
-	s.UpsertFavorite(Favorite{Label: "dev", Role: "Owner", Scope: "/subscriptions/xyz", Duration: "2h", Key: 2})
+	s.UpsertFavorite(Favorite{Label: "prod", Role: "Reader", Scope: "/subscriptions/abc", Duration: "1h", Justification: "test reason", Key: 1})
+	s.UpsertFavorite(Favorite{Label: "dev", Role: "Owner", Scope: "/subscriptions/xyz", Duration: "2h", Justification: "test reason", Key: 2})
 
 	f, ok := s.FavoriteByKey(1)
 	if !ok || f.Label != "prod" {
@@ -40,7 +40,7 @@ func TestStoreFavorites(t *testing.T) {
 	}
 
 	// Update
-	s.UpsertFavorite(Favorite{Label: "prod", Role: "Contributor", Scope: "/subscriptions/abc", Duration: "1h", Key: 1})
+	s.UpsertFavorite(Favorite{Label: "prod", Role: "Contributor", Scope: "/subscriptions/abc", Duration: "1h", Justification: "test reason", Key: 1})
 	f, _ = s.FavoriteByKey(1)
 	if f.Role != "Contributor" {
 		t.Fatalf("expected updated role Contributor, got %q", f.Role)
@@ -99,7 +99,7 @@ func TestStoreConfigPersistence(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s.UpsertFavorite(Favorite{Label: "test", Role: "Reader", Scope: "/sub/abc", Duration: "1h", Key: 3})
+	s.UpsertFavorite(Favorite{Label: "test", Role: "Reader", Scope: "/sub/abc", Duration: "1h", Justification: "test reason", Key: 3})
 	if err := s.SaveConfig(); err != nil {
 		t.Fatal(err)
 	}
@@ -111,6 +111,46 @@ func TestStoreConfigPersistence(t *testing.T) {
 	f, ok := s2.FavoriteByKey(3)
 	if !ok || f.Label != "test" {
 		t.Fatalf("expected persisted favorite, got ok=%v label=%q", ok, f.Label)
+	}
+	if f.Justification != "test reason" {
+		t.Fatalf("expected persisted justification %q, got %q", "test reason", f.Justification)
+	}
+}
+
+func TestFavoriteComplete(t *testing.T) {
+	tests := []struct {
+		name string
+		fav  Favorite
+		want bool
+	}{
+		{
+			name: "all fields set",
+			fav:  Favorite{Role: "Reader", Scope: "/sub/abc", Duration: "1h", Justification: "reason"},
+			want: true,
+		},
+		{
+			name: "missing justification",
+			fav:  Favorite{Role: "Reader", Scope: "/sub/abc", Duration: "1h"},
+			want: false,
+		},
+		{
+			name: "missing role",
+			fav:  Favorite{Scope: "/sub/abc", Duration: "1h", Justification: "reason"},
+			want: false,
+		},
+		{
+			name: "all empty",
+			fav:  Favorite{},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.fav.Complete()
+			if got != tc.want {
+				t.Errorf("Complete() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/tui/activate/wizard.go
+++ b/internal/tui/activate/wizard.go
@@ -35,6 +35,7 @@ type Deps struct {
 	TimeStr     string   // from --time flag
 	Justific    string   // from --justification flag
 	AutoSubmit  bool     // from --yes flag
+	Silent      bool     // suppress role-list render during direct favorite activation
 	Store       *state.Store
 	LoadRoles   func() ([]azure.Role, error)
 	LoadActive  func() ([]azure.ActiveAssignment, error)
@@ -233,7 +234,7 @@ func roleListConsumed(prev, next RoleList, msg tea.Msg) bool {
 
 // View renders the current step with a wizard header.
 func (w Wizard) View() string {
-	if w.deps.AutoSubmit && w.step == stepRoleList {
+	if w.deps.Silent && w.step == stepRoleList {
 		return ""
 	}
 	var sb strings.Builder

--- a/internal/tui/activate/wizard.go
+++ b/internal/tui/activate/wizard.go
@@ -233,6 +233,9 @@ func roleListConsumed(prev, next RoleList, msg tea.Msg) bool {
 
 // View renders the current step with a wizard header.
 func (w Wizard) View() string {
+	if w.deps.AutoSubmit && w.step == stepRoleList {
+		return ""
+	}
 	var sb strings.Builder
 	sb.WriteString(w.renderStepIndicator() + "\n\n")
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -71,6 +71,7 @@ type AppModel struct {
 	favoritesModel  favorites.Model
 	principalID     string
 	userReady       bool
+	favoritePending bool
 	width           int
 	height          int
 	isDark          bool
@@ -158,6 +159,14 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case activate.WizardDoneMsg:
+		if m.favoritePending {
+			m.favoritePending = false
+			summary, err := buildActivationSummary(msg.Results)
+			notice := strings.TrimRight(summary, "\n")
+			m.dashboardModel.SetNotice(notice, err != nil)
+			m.screen = ScreenDashboard
+			return m, nil
+		}
 		m.exitSummary, m.exitErr = buildActivationSummary(msg.Results)
 		return m, tea.Quit
 
@@ -322,6 +331,14 @@ func (m *AppModel) startWizard(fav *state.Favorite) tea.Cmd {
 			_, err := client.ActivateRole(callCtx, role, pid, justification, minutes, targetScope)
 			return err
 		},
+	}
+
+	if fav != nil && fav.Justification != "" && deps.Justific == "" {
+		deps.Justific = fav.Justification
+	}
+	if fav != nil && fav.Complete() {
+		deps.AutoSubmit = true
+		m.favoritePending = true
 	}
 
 	m.wizardModel = activate.New(m.theme, m.keys, deps)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -146,7 +146,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// If a headless command was pending, dispatch it now.
 		switch m.a.Config.Command {
 		case app.CmdActivate:
-			return m, m.startWizard(nil)
+			return m, m.startWizard(nil, false)
 		case app.CmdDeactivate:
 			return m, m.startDeactivate()
 		case app.CmdStatus:
@@ -171,6 +171,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 
 	case activate.WizardCancelMsg:
+		m.favoritePending = false
 		m.screen = ScreenDashboard
 		return m, nil
 
@@ -188,13 +189,13 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case favorites.ActivateMsg:
 		fav := msg.Favorite
-		return m, m.startWizard(&fav)
+		return m, m.startWizard(&fav, false)
 
 	case dashboard.ActivateMsg:
 		if !m.userReady {
 			return m, nil
 		}
-		return m, m.startWizard(msg.Favorite)
+		return m, m.startWizard(msg.Favorite, msg.Favorite != nil && msg.Favorite.Complete())
 
 	case tea.KeyPressMsg:
 		if msg.String() == "ctrl+c" {
@@ -270,7 +271,8 @@ func (m *AppModel) startStatus() tea.Cmd {
 
 // startWizard builds the Wizard deps and switches to the activate screen.
 // fav may be nil (full wizard) or point to a pre-filled favorite.
-func (m *AppModel) startWizard(fav *state.Favorite) tea.Cmd {
+// autoSubmit skips all interactive steps and submits immediately.
+func (m *AppModel) startWizard(fav *state.Favorite, autoSubmit bool) tea.Cmd {
 	if m.principalID == "" {
 		m.exitSummary = "error: user identity not yet resolved — please retry\n"
 		m.exitErr = errors.New("principal ID unavailable")
@@ -336,7 +338,7 @@ func (m *AppModel) startWizard(fav *state.Favorite) tea.Cmd {
 	if fav != nil && fav.Justification != "" && deps.Justific == "" {
 		deps.Justific = fav.Justification
 	}
-	if fav != nil && fav.Complete() {
+	if autoSubmit {
 		deps.AutoSubmit = true
 		m.favoritePending = true
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -171,6 +171,9 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 
 	case activate.WizardCancelMsg:
+		if m.favoritePending {
+			m.dashboardModel.SetNotice("activation cancelled — verify role/scope in favorites (f)", true)
+		}
 		m.favoritePending = false
 		m.screen = ScreenDashboard
 		return m, nil
@@ -340,6 +343,7 @@ func (m *AppModel) startWizard(fav *state.Favorite, autoSubmit bool) tea.Cmd {
 	}
 	if autoSubmit {
 		deps.AutoSubmit = true
+		deps.Silent = true
 		m.favoritePending = true
 	}
 

--- a/internal/tui/dashboard/dashboard.go
+++ b/internal/tui/dashboard/dashboard.go
@@ -31,6 +31,8 @@ type Model struct {
 	store     *state.Store
 	userReady bool
 	authErr   string
+	notice    string
+	noticeErr bool
 	width     int
 	height    int
 }
@@ -51,6 +53,9 @@ func (m *Model) SetReady() { m.userReady = true; m.authErr = "" }
 // SetAuthErr records an authentication failure message to display.
 func (m *Model) SetAuthErr(msg string) { m.authErr = msg }
 
+// SetNotice sets an informational or error notice to display on the dashboard.
+func (m *Model) SetNotice(msg string, isErr bool) { m.notice = msg; m.noticeErr = isErr }
+
 // Init is a no-op — the landing screen loads no data.
 func (m Model) Init() tea.Cmd { return nil }
 
@@ -62,6 +67,8 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		m.height = msg.Height
 
 	case tea.KeyPressMsg:
+		m.notice = ""
+		m.noticeErr = false
 		switch {
 		case key.Matches(msg, m.keys.Quit):
 			return m, tea.Quit
@@ -75,6 +82,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			if len(s) == 1 && s[0] >= '1' && s[0] <= '9' {
 				n := int(s[0] - '0')
 				if fav, ok := m.store.FavoriteByKey(n); ok {
+					if !fav.Complete() {
+						m.notice = fmt.Sprintf("favorite %q incomplete: missing %s", fav.Label, fav.MissingFields())
+						m.noticeErr = true
+						return m, nil
+					}
 					return m, func() tea.Msg { return ActivateMsg{Favorite: &fav} }
 				}
 			}
@@ -109,6 +121,14 @@ func (m Model) View() string {
 			sb.WriteString(line + "\n")
 		}
 		sb.WriteString("\n")
+	}
+
+	if m.notice != "" {
+		style := lipgloss.NewStyle().Foreground(m.theme.Success)
+		if m.noticeErr {
+			style = lipgloss.NewStyle().Foreground(m.theme.Danger)
+		}
+		sb.WriteString(style.Render(m.notice) + "\n\n")
 	}
 
 	if m.authErr != "" {


### PR DESCRIPTION
## What

Pressing a favorite shortcut key (1–9) now activates immediately when the favorite is fully configured — no wizard prompts.

## Behaviour

| Favorite state | Key press result |
|---|---|
| `role` + `scope` + `duration` + `justification` all set | Activates immediately, returns to dashboard with result notice |
| Any field missing | Error notice on dashboard, no activation |
| From favorites editor (f) | Always opens wizard at the missing step (unchanged) |

## Config

```toml
[[favorites]]
label         = "Prod reader"
role          = "Reader"
scope         = "/subscriptions/419a26ee-..."
duration      = "8h"
justification = "Workshop access"
key           = 1
```

## Changes

- `state.Favorite`: add `Justification` field, `Complete()` method, `MissingFields()` helper
- `dashboard.Model`: notice banner (success/error), incomplete-favorite gate on 1–9 shortcuts
- `app.go`: inject `fav.Justification` into wizard deps; set `AutoSubmit=true` + `favoritePending=true` for complete favorites; `WizardDoneMsg` returns to dashboard with notice when `favoritePending`
- Docs: README config example updated; AGENTS.md favorites behaviour section added