### PR TITLE
chore: bump mise tools to go 1.26.2 and goreleaser 2.15.4

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,3 @@
 [tools]
-go = "1.26.1"
-goreleaser = "2.15.2"
+go = "1.26.2"
+goreleaser = "2.15.4"


### PR DESCRIPTION
Aligns .mise.toml with go.mod after Renovate PR #48 bumped the go directive to 1.26.2. Also picks up goreleaser 2.15.4.