### PR TITLE
fix: allow MG activation and bare GUID scope filters

### DIFF
--- a/.agents/skills/golang/references/azure-pim-api.md
+++ b/.agents/skills/golang/references/azure-pim-api.md
@@ -176,10 +176,18 @@ GET https://management.azure.com{mgScope}/providers/Microsoft.Authorization/elig
 the management group. For deeply nested MG hierarchies this may return zero results even
 when subscriptions exist at lower levels.
 
-Handles pagination via `nextLink`. Returns three item types:
+Handles pagination via `nextLink`. Confirmed live payload shape is flat items with
+`id`, `name`, `type`, and sometimes `properties.displayName` (often empty). Match
+`type` by case-insensitive substring, not suffix, because Azure returns bare singular
+strings such as `"managementgroup"`, `"subscription"`, and `"resourcegroup"`:
 - `type` contains `"subscription"` → subscription child scope
 - `type` contains `"resourcegroup"` → resource group child scope
 - `type` contains `"managementgroup"` → child management group
+
+Do not use ARM path segment counts to infer direct vs nested children. Management group
+IDs are flat (`/providers/Microsoft.Management/managementGroups/{id}`) regardless of
+hierarchy depth, and subscription IDs are flat (`/subscriptions/{id}`) regardless of
+which management group contains them.
 
 **Child management groups must be treated as expandable nodes**, not discarded. A top-level MG
 (e.g. `Omnia`) may return only child MGs with no subscriptions at the first level. Each child MG
@@ -201,7 +209,9 @@ with `$getAllChildren=true` is the correct and sufficient path.
 ```json
 {
   "value": [
-    { "id": "/subscriptions/{subID}/resourceGroups/{rgName}", "name": "{rgName}", "type": "resourcegroup" }
+    { "id": "/providers/Microsoft.Management/managementGroups/Omnia-Standalone", "name": "Omnia-Standalone", "type": "managementgroup", "properties": { "displayName": "" } },
+    { "id": "/subscriptions/{subID}", "name": "{subID}", "type": "subscription", "properties": { "displayName": "" } },
+    { "id": "/subscriptions/{subID}/resourceGroups/{rgName}", "name": "{rgName}", "type": "resourcegroup", "properties": { "displayName": "" } }
   ],
   "nextLink": "..."
 }
@@ -234,6 +244,7 @@ eligibilities is impossible without a pre-existing assignment.
 |---|---|---|
 | PUT `{rgScope}/…/roleAssignmentScheduleRequests/{uuid}` | **HTTP 403 AuthorizationFailed** | Azure scope pre-check fails |
 | GET `{rgScope}/…/roleAssignmentSchedules` | **HTTP 500** | No read access; `isRoleActiveAt` swallows this as "not active" — expected |
+| PUT any scope | **HTTP 400 PendingRoleAssignmentRequest** | An activation request is already pending; treat as success-equivalent |
 
 ### Fallback pattern (implemented in `ActivateRole`)
 

--- a/.agents/skills/golang/references/azure-pim-api.md
+++ b/.agents/skills/golang/references/azure-pim-api.md
@@ -176,8 +176,19 @@ GET https://management.azure.com{mgScope}/providers/Microsoft.Authorization/elig
 the management group. For deeply nested MG hierarchies this may return zero results even
 when subscriptions exist at lower levels.
 
-Handles pagination via `nextLink`. Returns both subscriptions (`type` contains `"subscription"`)
-and resource groups (`type` contains `"resourcegroup"`).
+Handles pagination via `nextLink`. Returns three item types:
+- `type` contains `"subscription"` → subscription child scope
+- `type` contains `"resourcegroup"` → resource group child scope
+- `type` contains `"managementgroup"` → child management group
+
+**Child management groups must be treated as expandable nodes**, not discarded. A top-level MG
+(e.g. `Omnia`) may return only child MGs with no subscriptions at the first level. Each child MG
+is both selectable (the user can activate at the MG scope itself) and expandable (the user can
+drill into it to find its own children, which may be further MGs or subscriptions).
+
+`ListManagementGroupChildren` returns `([]ManagementGroup, []Subscription, error)`.
+`ListManagementGroupSubscriptions` is a thin wrapper that discards the MG slice — use it only
+for callers that genuinely need subscriptions only (e.g. headless mode).
 
 An **empty response is valid** — it means the caller has no PIM-eligible child scopes under
 that MG, not that the API failed.

--- a/.agents/skills/golang/references/azure-pim-api.md
+++ b/.agents/skills/golang/references/azure-pim-api.md
@@ -37,7 +37,7 @@ calling user's eligibilities only.
       "scope": "/providers/Microsoft.Management/managementGroups/{mgID}",
       "roleDefinitionId": "/providers/Microsoft.Management/managementGroups/{mgID}/providers/Microsoft.Authorization/roleDefinitions/{guid}",
       "expandedProperties": {
-        "scope": { "displayName": "Contoso-Platform-QA" },
+        "scope": { "displayName": "example-subscription" },
         "roleDefinition": { "displayName": "Reader" }
       }
     }
@@ -190,7 +190,7 @@ hierarchy depth, and subscription IDs are flat (`/subscriptions/{id}`) regardles
 which management group contains them.
 
 **Child management groups must be treated as expandable nodes**, not discarded. A top-level MG
-(e.g. `Contoso`) may return only child MGs with no subscriptions at the first level. Each child MG
+(e.g. `example-mg`) may return only child MGs with no subscriptions at the first level. Each child MG
 is both selectable (the user can activate at the MG scope itself) and expandable (the user can
 drill into it to find its own children, which may be further MGs or subscriptions).
 
@@ -209,7 +209,7 @@ with `$getAllChildren=true` is the correct and sufficient path.
 ```json
 {
   "value": [
-    { "id": "/providers/Microsoft.Management/managementGroups/Contoso-Standalone", "name": "Contoso-Standalone", "type": "managementgroup", "properties": { "displayName": "" } },
+    { "id": "/providers/Microsoft.Management/managementGroups/example-child-mg", "name": "example-child-mg", "type": "managementgroup", "properties": { "displayName": "" } },
     { "id": "/subscriptions/{subID}", "name": "{subID}", "type": "subscription", "properties": { "displayName": "" } },
     { "id": "/subscriptions/{subID}/resourceGroups/{rgName}", "name": "{rgName}", "type": "resourcegroup", "properties": { "displayName": "" } }
   ],
@@ -262,7 +262,7 @@ The retry uses the same request body — in particular the same MG-level
 `linkedRoleEligibilityScheduleId`. Azure accepts this and activates the role at
 subscription scope rather than the narrower RG.
 
-### Confirmed via curl (Contoso-Platform-QA / my-rg)
+### Confirmed via curl (example-subscription / my-rg)
 
 ```bash
 # RG scope → 403

--- a/.agents/skills/golang/references/azure-pim-api.md
+++ b/.agents/skills/golang/references/azure-pim-api.md
@@ -11,8 +11,7 @@ role-schedule endpoints: **`2020-10-01`**.
 | Fetch active assignments | GET | `/providers/Microsoft.Authorization/roleAssignmentScheduleInstances` |
 | Check active at scope | GET | `{scope}/providers/Microsoft.Authorization/roleAssignmentSchedules` |
 | Activate / extend / deactivate | PUT | `{scope}/providers/Microsoft.Authorization/roleAssignmentScheduleRequests/{uuid}` |
-| List eligible child resources | GET | `{mgScope}/providers/Microsoft.Authorization/eligibleChildResources` |
-| List MG subscriptions (fallback) | GET | `/providers/Microsoft.Management/managementGroups/{mgID}/subscriptions` |
+| List eligible child resources | GET | `{mgScope}/providers/Microsoft.Authorization/eligibleChildResources?$getAllChildren=true` |
 | List RGs for subscription | GET | `/subscriptions/{subID}/resourceGroups` |
 
 ---
@@ -170,11 +169,23 @@ Used to enumerate scopes the user can narrow activation to.
 ```
 GET https://management.azure.com{mgScope}/providers/Microsoft.Authorization/eligibleChildResources
     ?api-version=2020-10-01
-    &getAllChildren=true
+    &$getAllChildren=true
 ```
+
+**`$getAllChildren=true` is required.** Without it the API returns only direct children of
+the management group. For deeply nested MG hierarchies this may return zero results even
+when subscriptions exist at lower levels.
 
 Handles pagination via `nextLink`. Returns both subscriptions (`type` contains `"subscription"`)
 and resource groups (`type` contains `"resourcegroup"`).
+
+An **empty response is valid** — it means the caller has no PIM-eligible child scopes under
+that MG, not that the API failed.
+
+**Do not fall back to the legacy `managementGroups/{id}/subscriptions` endpoint.** That
+endpoint requires `Microsoft.Management/managementGroups/subscriptions/read`, which
+PIM-eligible users typically do not have. The portal never uses it; `eligibleChildResources`
+with `$getAllChildren=true` is the correct and sufficient path.
 
 ```json
 {
@@ -190,12 +201,11 @@ and resource groups (`type` contains `"resourcegroup"`).
 ## 7. Constants (internal/azure/client.go)
 
 ```go
-apiVersion                             = "2020-10-01"   // all PIM role-schedule endpoints
-managementGroupSubscriptionsAPIVersion = "2023-04-01"   // MG subscriptions fallback
-eligibleChildResourcesAPIVersion       = "2020-10-01"   // eligibleChildResources
-resourceGroupsAPIVersion               = "2021-04-01"   // ARM resourceGroups list
-armEndpoint                            = "https://management.azure.com"
-graphEndpoint                          = "https://graph.microsoft.com/v1.0"
+apiVersion                        = "2020-10-01"   // all PIM role-schedule endpoints
+eligibleChildResourcesAPIVersion  = "2020-10-01"   // eligibleChildResources
+resourceGroupsAPIVersion          = "2021-04-01"   // ARM resourceGroups list
+armEndpoint                       = "https://management.azure.com"
+graphEndpoint                     = "https://graph.microsoft.com/v1.0"
 ```
 
 ---

--- a/.agents/skills/golang/references/azure-pim-api.md
+++ b/.agents/skills/golang/references/azure-pim-api.md
@@ -37,7 +37,7 @@ calling user's eligibilities only.
       "scope": "/providers/Microsoft.Management/managementGroups/{mgID}",
       "roleDefinitionId": "/providers/Microsoft.Management/managementGroups/{mgID}/providers/Microsoft.Authorization/roleDefinitions/{guid}",
       "expandedProperties": {
-        "scope": { "displayName": "Omnia-Classic-QA" },
+        "scope": { "displayName": "Contoso-Platform-QA" },
         "roleDefinition": { "displayName": "Reader" }
       }
     }
@@ -190,7 +190,7 @@ hierarchy depth, and subscription IDs are flat (`/subscriptions/{id}`) regardles
 which management group contains them.
 
 **Child management groups must be treated as expandable nodes**, not discarded. A top-level MG
-(e.g. `Omnia`) may return only child MGs with no subscriptions at the first level. Each child MG
+(e.g. `Contoso`) may return only child MGs with no subscriptions at the first level. Each child MG
 is both selectable (the user can activate at the MG scope itself) and expandable (the user can
 drill into it to find its own children, which may be further MGs or subscriptions).
 
@@ -209,7 +209,7 @@ with `$getAllChildren=true` is the correct and sufficient path.
 ```json
 {
   "value": [
-    { "id": "/providers/Microsoft.Management/managementGroups/Omnia-Standalone", "name": "Omnia-Standalone", "type": "managementgroup", "properties": { "displayName": "" } },
+    { "id": "/providers/Microsoft.Management/managementGroups/Contoso-Standalone", "name": "Contoso-Standalone", "type": "managementgroup", "properties": { "displayName": "" } },
     { "id": "/subscriptions/{subID}", "name": "{subID}", "type": "subscription", "properties": { "displayName": "" } },
     { "id": "/subscriptions/{subID}/resourceGroups/{rgName}", "name": "{rgName}", "type": "resourcegroup", "properties": { "displayName": "" } }
   ],
@@ -262,11 +262,11 @@ The retry uses the same request body — in particular the same MG-level
 `linkedRoleEligibilityScheduleId`. Azure accepts this and activates the role at
 subscription scope rather than the narrower RG.
 
-### Confirmed via curl (March 2026, Omnia-Classic-QA / Q912-log)
+### Confirmed via curl (Contoso-Platform-QA / my-rg)
 
 ```bash
 # RG scope → 403
-curl -X PUT ".../resourceGroups/Q912-log/providers/Microsoft.Authorization/
+curl -X PUT ".../resourceGroups/my-rg/providers/Microsoft.Authorization/
   roleAssignmentScheduleRequests/{uuid}?api-version=2020-10-01" ...
 # {"error":{"code":"AuthorizationFailed","message":"does not have authorization to
 #  perform action 'Microsoft.Resources/subscriptions/resourceGroups/read' ..."}}

--- a/.agents/skills/golang/references/patterns.md
+++ b/.agents/skills/golang/references/patterns.md
@@ -162,7 +162,7 @@ principalID := user.ID
 type Deps struct {
     PrincipalID string
     LoadRoles   func() ([]azure.Role, error)
-    LoadSubs    func(mgID string) ([]azure.Subscription, error)
+    LoadSubs    func(mgID string) ([]azure.ManagementGroup, []azure.Subscription, error)
     Activate    func(role azure.Role, pid, just string, mins int, scope string) error
     // ...
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,9 @@ jobs:
         run: go test ./...
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: Validate tag format
+        run: |
+          TAG="${{ github.ref_name }}"
+          if echo "$TAG" | grep -q 'dirty'; then
+            echo "✗ Tag '$TAG' contains '-dirty' — commit all changes before releasing"
+            exit 1
+          fi
+          if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-dev\.[0-9]+-g[0-9a-f]+)?$'; then
+            echo "✗ Tag '$TAG' does not match required format: v<major>.<minor>.<patch> or v<major>.<minor>.<patch>-dev.<n>-g<sha>"
+            exit 1
+          fi
+
       - name: Run tests
         run: go test ./...
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,7 +38,7 @@ checksum:
 changelog:
   use: git
 snapshot:
-  name_template: '{{ .Tag }}'
+  version_template: '{{ .Tag }}'
 release:
   github:
     owner: jeircul

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,7 +37,10 @@ checksum:
   name_template: '{{ .ProjectName }}_checksums.txt'
 changelog:
   use: git
+snapshot:
+  name_template: '{{ .Tag }}'
 release:
   github:
     owner: jeircul
     name: pim
+  prerelease: auto

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 project_name: pim
 before:
   hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,39 @@ cat /etc/ssl/certs/ca-certificates.crt /tmp/corp-ca.pem > /tmp/ca-bundle.crt
 GOTOOLCHAIN=local SSL_CERT_FILE=/tmp/ca-bundle.crt go mod tidy
 ```
 
+## Releases
+
+Two release tiers, both require a clean `task fmt && task test` pass.
+
+| Task | Branch | Result |
+|------|--------|--------|
+| `task release:dev` | any non-main, non-renovate | GitHub pre-release with auto-computed `vX.Y.Z-dev.N-gSHA` tag |
+| `task release:stable` | `main` only, up to date with `origin/main` | Stable GitHub release; prompts for `vX.Y.Z` tag |
+
+### Branch naming (advisory)
+
+| Prefix | Purpose |
+|--------|---------|
+| `fix/` | Bug fixes |
+| `feat/` | New features |
+| `chore/` | Maintenance, deps, docs |
+
+### Install commands
+
+```powershell
+# Latest stable
+irm https://raw.githubusercontent.com/jeircul/pim/main/scripts/install.ps1 | iex
+
+# Latest pre-release (dev)
+irm https://raw.githubusercontent.com/jeircul/pim/main/scripts/install.ps1 | iex -Dev
+```
+
+### Rules
+
+- Never push a `v*` tag manually — always use `task release:dev` or `task release:stable`.
+- `release:stable` requires `main` to be up to date with `origin/main` (fetches before checking).
+- `release:dev` is blocked on `main` and `renovate/*` branches.
+
 ## Rules
 
 - `internal/` only. No `pkg/`, no Cobra/urfave, no testify, no logging libs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ irm https://raw.githubusercontent.com/jeircul/pim/main/scripts/install.ps1 | iex
 - RG-scope activation returns 403 (chicken-and-egg). The client falls back to subscription scope automatically.
 - `roleAssignmentSchedules` GET at RG scope returns 500 when the caller lacks read access. Treated as "not active".
 - `GetEligibleRoles` and `GetActiveAssignments` paginate via `nextLink`.
+- `PendingRoleAssignmentRequest` (HTTP 400) is treated as success at all scopes — the role is already activating.
 
 Full API reference: `.agents/skills/golang/references/azure-pim-api.md`.
 
@@ -102,6 +103,7 @@ Full API reference: `.agents/skills/golang/references/azure-pim-api.md`.
 - `--role` and `--scope` use exact-first, substring-fallback matching.
 - Multiple substring matches with no exact match returns an ambiguity error.
 - ARM scope paths take precedence over display-name matching.
+- Bare subscription GUIDs expand to `/subscriptions/<guid>`; bare non-GUID tokens expand to the matching MG ARM path.
 
 ## Favorites behaviour
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Scope tree: `/` key opens a filter input to search scopes by name.
+- Scope tree: viewport scrolling for large tenants with many scopes.
+- Headless `--scope`: bare subscription GUID (e.g. `00000000-0000-0000-0000-000000000000`) expands to `/subscriptions/<guid>` automatically.
+- Headless `--scope`: bare non-GUID token expands to the matching management group ARM path.
+- Scope tree: child management group nodes are expandable; MG root is selectable even when child listing returns 403.
+
+### Fixed
+
+- MG root node was not selectable when listing its children returned 403.
+- Scope tree rendered only 1 row before the first terminal resize event.
+- `esc`/`enter` key events bubbled through the scope tree filter input to the wizard back/cancel handlers.
+
+### Changed
+
+- `ListManagementGroupChildren` now returns child management groups alongside subscriptions `([]ManagementGroup, []Subscription, error)`.
+- `eligibleChildResources` always uses `$getAllChildren=true`; the legacy per-level endpoint is removed.
+- `PendingRoleAssignmentRequest` (HTTP 400) is treated as success at all scopes — the role is already activating.
+- GoReleaser config updated to `version: 2` with `snapshot.version_template`.
+
+### Removed
+
+- Legacy `managementGroups/{id}/subscriptions` endpoint; replaced by `$getAllChildren=true` on `eligibleChildResources`.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Terminal UI for activating, deactivating, and inspecting Azure Privileged Identi
 
 - 🖥️ Full-screen TUI — dashboard, activation wizard, status, deactivation, favorites management
 - 🎯 Flags pre-fill wizard steps and auto-advance; `--headless` bypasses the TUI for scripting
+- 🔭 Scope tree with `/` filter and viewport scrolling for large tenants
 - 🎨 Adaptive theme — works on light and dark terminals
 - ⭐ Favorites with 1–9 number-key shortcuts for instant re-activation
 - 💾 TOML state persistence — remembers recent justifications and favorites across sessions
@@ -48,6 +49,9 @@ pim activate --role Reader
 # Jump straight to options step — scope matched by display name substring
 pim activate --role Reader --scope my-subscription
 
+# Bare subscription GUID expands to /subscriptions/<guid>
+pim activate --role Reader --scope 00000000-0000-0000-0000-000000000000
+
 # Auto-submit with no TUI interaction
 pim activate \
   --role Reader \
@@ -62,6 +66,7 @@ pim activate \
 ```sh
 # Activate — only --role is required; --time defaults to 1h
 # --scope matches ARM path first, then display-name substring
+# Bare GUIDs expand to /subscriptions/<guid>; bare non-GUID tokens expand to MG ARM paths
 pim activate --headless \
   --role Reader \
   --scope my-subscription \
@@ -91,7 +96,7 @@ Both flags resolve in two passes:
 2. **Substring fallback** if no exact match. `--scope prod` matches `my-prod-subscription` when it's the only match.
 3. **Ambiguity errors out.** If multiple values match by substring with no exact match, the command exits non-zero and lists the candidates instead of silently picking one.
 
-ARM scope paths (`/subscriptions/...`) take precedence over display-name matching.
+ARM scope paths (`/subscriptions/...`) take precedence over display-name matching. Bare subscription GUIDs (e.g. `00000000-0000-0000-0000-000000000000`) are automatically expanded to `/subscriptions/<guid>`; bare non-GUID tokens are expanded to the matching MG ARM path.
 
 ## 🐚 Shell completions
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,16 +58,96 @@ tasks:
     desc: Print release instructions
     cmds:
       - |
-          echo "1. Ensure git status is clean and up to date"
-          echo "2. Set a tag: git tag vX.Y.Z && git push origin vX.Y.Z"
-          echo "3. Optionally run task release:snapshot (dry run)"
-          echo "4. Run task release:publish to push artefacts (requires GITHUB_TOKEN)"
+          echo "Use 'task release:dev' (non-main branch) or 'task release:stable' (main only)"
     silent: true
 
-  release:publish:
-    desc: Publish a release to GitHub (requires GITHUB_TOKEN)
+  release:dev:
+    desc: Publish a pre-release from the current non-main branch (requires GITHUB_TOKEN)
     cmds:
-      - goreleaser release --clean
+      - |
+          BRANCH=$(git branch --show-current)
+          if [ "$BRANCH" = "main" ]; then
+            echo "✗ release:dev must not run on main — use task release:stable"
+            exit 1
+          fi
+          case "$BRANCH" in
+            renovate/*) echo "✗ release:dev is not allowed on renovate/* branches"; exit 1 ;;
+          esac
+          RAW=$(git describe --tags --long --dirty 2>/dev/null || echo "")
+          if [ -z "$RAW" ]; then
+            N=$(git rev-list --count HEAD)
+            SHA=$(git rev-parse --short HEAD)
+            VERSION="v0.0.0-dev.${N}-g${SHA}"
+          else
+            BASE=$(echo "$RAW" | sed 's/-[0-9]*-g[0-9a-f]*\(-dirty\)*$//')
+            N=$(echo "$RAW" | sed 's/.*-\([0-9]*\)-g[0-9a-f]*/\1/')
+            SHA=$(echo "$RAW" | sed 's/.*-g\([0-9a-f]*\).*/\1/' | sed 's/-dirty//')
+            DIRTY=$(echo "$RAW" | grep -q 'dirty' && echo "-dirty" || echo "")
+            if [ "$N" = "0" ] && [ -z "$DIRTY" ]; then
+              echo "✗ HEAD is already tagged as $BASE — nothing to pre-release"
+              exit 1
+            fi
+            VERSION="${BASE}-dev.${N}-g${SHA}${DIRTY}"
+          fi
+          if echo "$VERSION" | grep -q 'dirty'; then
+            echo "✗ Working tree is dirty — commit or stash changes before releasing"
+            exit 1
+          fi
+          echo "Proposed version: $VERSION"
+          printf "Publish pre-release %s? (y/N): " "$VERSION"
+          read -r CONFIRM
+          if [ "$CONFIRM" != "y" ] && [ "$CONFIRM" != "Y" ]; then
+            echo "Aborted."
+            exit 1
+          fi
+          git tag "$VERSION"
+          git push origin "$VERSION"
+          echo ""
+          echo "✓ Tag $VERSION pushed — GitHub Actions will publish the pre-release."
+          echo "Install: irm https://raw.githubusercontent.com/jeircul/pim/main/scripts/install.ps1 | iex -Dev"
+    preconditions:
+      - sh: "task fmt"
+        msg: "fmt failed"
+      - sh: "task test"
+        msg: "tests failed"
+
+  release:stable:
+    desc: Tag and publish a stable release from main (requires GITHUB_TOKEN)
+    cmds:
+      - |
+          BRANCH=$(git branch --show-current)
+          if [ "$BRANCH" != "main" ]; then
+            echo "✗ release:stable must run on main (current: $BRANCH)"
+            exit 1
+          fi
+          git fetch origin main --quiet
+          BEHIND=$(git rev-list --count HEAD..origin/main)
+          if [ "$BEHIND" -gt 0 ]; then
+            echo "✗ main is $BEHIND commit(s) behind origin/main — pull first"
+            exit 1
+          fi
+          printf "Version? (e.g. v0.6.0): "
+          read -r VERSION
+          if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "✗ Invalid version '$VERSION' — must match v<major>.<minor>.<patch>"
+            exit 1
+          fi
+          printf "Tag and release %s? (y/N): " "$VERSION"
+          read -r CONFIRM
+          if [ "$CONFIRM" != "y" ] && [ "$CONFIRM" != "Y" ]; then
+            echo "Aborted."
+            exit 1
+          fi
+          git tag "$VERSION"
+          git push origin "$VERSION"
+          echo ""
+          echo "✓ Tag $VERSION pushed — GitHub Actions will publish the release."
+          echo "Install: irm https://raw.githubusercontent.com/jeircul/pim/main/scripts/install.ps1 | iex"
+    preconditions:
+      - sh: "task fmt"
+        msg: "fmt failed"
+      - sh: "task test"
+        msg: "tests failed"
 
   release:snapshot:
     desc: Generate release artefacts locally without publishing

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -73,26 +73,17 @@ tasks:
           case "$BRANCH" in
             renovate/*) echo "✗ release:dev is not allowed on renovate/* branches"; exit 1 ;;
           esac
-          RAW=$(git describe --tags --long --dirty 2>/dev/null || echo "")
-          if [ -z "$RAW" ]; then
-            N=$(git rev-list --count HEAD)
-            SHA=$(git rev-parse --short HEAD)
-            VERSION="v0.0.0-dev.${N}-g${SHA}"
-          else
-            BASE=$(echo "$RAW" | sed 's/-[0-9]*-g[0-9a-f]*\(-dirty\)*$//')
-            N=$(echo "$RAW" | sed 's/.*-\([0-9]*\)-g[0-9a-f]*/\1/')
-            SHA=$(echo "$RAW" | sed 's/.*-g\([0-9a-f]*\).*/\1/' | sed 's/-dirty//')
-            DIRTY=$(echo "$RAW" | grep -q 'dirty' && echo "-dirty" || echo "")
-            if [ "$N" = "0" ] && [ -z "$DIRTY" ]; then
-              echo "✗ HEAD is already tagged as $BASE — nothing to pre-release"
-              exit 1
-            fi
-            VERSION="${BASE}-dev.${N}-g${SHA}${DIRTY}"
+          BASE=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -z "$BASE" ]; then
+            BASE="v0.0.0"
           fi
-          if echo "$VERSION" | grep -q 'dirty'; then
-            echo "✗ Working tree is dirty — commit or stash changes before releasing"
+          N=$(git rev-list --count "${BASE}..HEAD" 2>/dev/null || git rev-list --count HEAD)
+          SHA=$(git rev-parse --short HEAD)
+          if [ "$N" = "0" ]; then
+            echo "✗ HEAD is already tagged as $BASE — nothing to pre-release"
             exit 1
           fi
+          VERSION="${BASE}-dev.${N}-g${SHA}"
           echo "Proposed version: $VERSION"
           printf "Publish pre-release %s? (y/N): " "$VERSION"
           read -r CONFIRM

--- a/internal/azure/activation.go
+++ b/internal/azure/activation.go
@@ -14,6 +14,10 @@ import (
 	"github.com/google/uuid"
 )
 
+// errCodePendingRequest is the Azure PIM error code returned when an activation
+// request is already in flight for the same role and scope.
+const errCodePendingRequest = "PendingRoleAssignmentRequest"
+
 // ActivateRole submits an activation or extension request.
 func (c *Client) ActivateRole(ctx context.Context, role Role, principalID, justification string, minutes int, targetScope string) (*ScheduleResponse, error) {
 	tok, err := c.armToken(ctx)
@@ -65,6 +69,9 @@ func (c *Client) ActivateRole(ctx context.Context, role Role, principalID, justi
 	resp, err := c.doRequest(ctx, http.MethodPut, reqURL, tok, bytes.NewReader(body))
 	if err != nil {
 		var apiErr *APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == 400 && strings.EqualFold(apiErr.Code, errCodePendingRequest) {
+			return &ScheduleResponse{}, nil
+		}
 		if IsResourceGroupScope(scopePath) && errors.As(err, &apiErr) &&
 			(apiErr.StatusCode == 403 || strings.EqualFold(apiErr.Code, "AuthorizationFailed")) {
 			return c.activateAtSubscriptionScope(ctx, req, scopePath, err)
@@ -102,6 +109,10 @@ func (c *Client) activateAtSubscriptionScope(ctx context.Context, req ScheduleRe
 
 	resp, err := c.doRequest(ctx, http.MethodPut, reqURL, tok, bytes.NewReader(body))
 	if err != nil {
+		var apiErr *APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == 400 && strings.EqualFold(apiErr.Code, errCodePendingRequest) {
+			return &ScheduleResponse{}, nil
+		}
 		return nil, fmt.Errorf("submit activation at %s (and fallback to subscription %s): %w", rgScope, subScope, errors.Join(rgErr, err))
 	}
 	defer resp.Body.Close()

--- a/internal/azure/azure_test.go
+++ b/internal/azure/azure_test.go
@@ -56,8 +56,8 @@ func TestManagementGroupIDFromScope(t *testing.T) {
 }
 
 func TestSubscriptionIDFromScope(t *testing.T) {
-	got := SubscriptionIDFromScope("/subscriptions/12345678-1234-1234-1234-123456789000/resourceGroups/my-rg")
-	if got != "12345678-1234-1234-1234-123456789000" {
+	got := SubscriptionIDFromScope("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg")
+	if got != "00000000-0000-0000-0000-000000000000" {
 		t.Fatalf("unexpected subscription id: %q", got)
 	}
 	if SubscriptionIDFromScope("/providers/Microsoft.Management/managementGroups/root") != "" {

--- a/internal/azure/client.go
+++ b/internal/azure/client.go
@@ -17,9 +17,9 @@ import (
 const (
 	apiVersion                       = "2020-10-01"
 	eligibleChildResourcesAPIVersion = "2020-10-01"
-	armEndpoint                            = "https://management.azure.com"
-	graphEndpoint                          = "https://graph.microsoft.com/v1.0"
-	httpTimeout                            = 30 * time.Second
+	armEndpoint                      = "https://management.azure.com"
+	graphEndpoint                    = "https://graph.microsoft.com/v1.0"
+	httpTimeout                      = 30 * time.Second
 )
 
 // Client handles Azure PIM operations.

--- a/internal/azure/client.go
+++ b/internal/azure/client.go
@@ -15,9 +15,8 @@ import (
 )
 
 const (
-	apiVersion                             = "2020-10-01"
-	managementGroupSubscriptionsAPIVersion = "2023-04-01"
-	eligibleChildResourcesAPIVersion       = "2020-10-01"
+	apiVersion                       = "2020-10-01"
+	eligibleChildResourcesAPIVersion = "2020-10-01"
 	armEndpoint                            = "https://management.azure.com"
 	graphEndpoint                          = "https://graph.microsoft.com/v1.0"
 	httpTimeout                            = 30 * time.Second

--- a/internal/azure/client.go
+++ b/internal/azure/client.go
@@ -29,9 +29,12 @@ type Client struct {
 }
 
 type childResource struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Type string `json:"type"`
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	Properties struct {
+		DisplayName string `json:"displayName"`
+	} `json:"properties"`
 }
 
 // NewClient creates a PIM client using the best available delegated credential.

--- a/internal/azure/discovery.go
+++ b/internal/azure/discovery.go
@@ -34,7 +34,6 @@ func classifyChildResources(resources []childResource) ([]ManagementGroup, []Sub
 		lower := strings.ToLower(item.Type)
 		switch {
 		case strings.Contains(lower, "resourcegroup"):
-			// not an MG-level child; skip
 		case strings.Contains(lower, "managementgroup"):
 			mgs = append(mgs, ManagementGroup{ID: item.Name, DisplayName: displayOr(item)})
 		case strings.Contains(lower, "subscription"):

--- a/internal/azure/discovery.go
+++ b/internal/azure/discovery.go
@@ -28,12 +28,14 @@ func (c *Client) ListManagementGroupChildren(ctx context.Context, mgID string) (
 	for _, item := range resources {
 		lower := strings.ToLower(item.Type)
 		switch {
-		case strings.Contains(lower, "managementgroup"):
-			mgs = append(mgs, ManagementGroup{ID: item.Name, DisplayName: item.Name})
-		case strings.Contains(lower, "subscription"):
+		case strings.HasSuffix(lower, "/resourcegroups"):
+			// not a direct child of an MG; ignore
+		case strings.HasSuffix(lower, "/managementgroups"):
+			mgs = append(mgs, ManagementGroup{ID: item.Name, DisplayName: displayOr(item)})
+		case strings.HasSuffix(lower, "/subscriptions"):
 			subID := SubscriptionIDFromScope(item.ID)
 			if subID != "" {
-				subs = append(subs, Subscription{ID: subID, DisplayName: item.Name})
+				subs = append(subs, Subscription{ID: subID, DisplayName: displayOr(item)})
 			}
 		}
 	}
@@ -58,7 +60,7 @@ func (c *Client) fetchEligibleChildResources(ctx context.Context, scope string) 
 	if err != nil {
 		return nil, err
 	}
-	reqURL := fmt.Sprintf("%s%s/providers/Microsoft.Authorization/eligibleChildResources?api-version=%s&$getAllChildren=true",
+	reqURL := fmt.Sprintf("%s%s/providers/Microsoft.Authorization/eligibleChildResources?api-version=%s",
 		armEndpoint, scope, eligibleChildResourcesAPIVersion)
 
 	var out []childResource
@@ -106,4 +108,11 @@ func (c *Client) ListEligibleResourceGroups(ctx context.Context, subscriptionID 
 		out = append(out, ResourceGroup{SubscriptionID: subscriptionID, Name: name, ID: item.ID})
 	}
 	return out, nil
+}
+
+func displayOr(item childResource) string {
+	if item.Properties.DisplayName != "" {
+		return item.Properties.DisplayName
+	}
+	return item.Name
 }

--- a/internal/azure/discovery.go
+++ b/internal/azure/discovery.go
@@ -9,21 +9,44 @@ import (
 	"strings"
 )
 
+// ListManagementGroupChildren returns the direct eligible children of a management group.
+// Children may be management groups or subscriptions.
+func (c *Client) ListManagementGroupChildren(ctx context.Context, mgID string) ([]ManagementGroup, []Subscription, error) {
+	mgID = strings.TrimSpace(mgID)
+	if mgID == "" {
+		return nil, nil, fmt.Errorf("management group id cannot be empty")
+	}
+
+	scope := fmt.Sprintf("/providers/Microsoft.Management/managementGroups/%s", url.PathEscape(mgID))
+	resources, err := c.fetchEligibleChildResources(ctx, scope)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var mgs []ManagementGroup
+	var subs []Subscription
+	for _, item := range resources {
+		lower := strings.ToLower(item.Type)
+		switch {
+		case strings.Contains(lower, "managementgroup"):
+			mgs = append(mgs, ManagementGroup{ID: item.Name, DisplayName: item.Name})
+		case strings.Contains(lower, "subscription"):
+			subID := SubscriptionIDFromScope(item.ID)
+			if subID != "" {
+				subs = append(subs, Subscription{ID: subID, DisplayName: item.Name})
+			}
+		}
+	}
+	return mgs, subs, nil
+}
+
 // ListManagementGroupSubscriptions returns subscriptions under a management group
 // that the caller is PIM-eligible to activate. Uses the eligibleChildResources API
 // with getAllChildren=true so nested subscriptions are included. An empty result
 // means no eligible child scopes exist, which is valid and not an error.
 func (c *Client) ListManagementGroupSubscriptions(ctx context.Context, mgID string) ([]Subscription, error) {
-	mgID = strings.TrimSpace(mgID)
-	if mgID == "" {
-		return nil, fmt.Errorf("management group id cannot be empty")
-	}
-
-	subs, err := c.listEligibleChildSubscriptions(ctx, mgID)
-	if err != nil {
-		return nil, err
-	}
-	return subs, nil
+	_, subs, err := c.ListManagementGroupChildren(ctx, mgID)
+	return subs, err
 }
 
 // fetchEligibleChildResources fetches PIM-eligible child resources under any
@@ -55,26 +78,6 @@ func (c *Client) fetchEligibleChildResources(ctx context.Context, scope string) 
 		resp.Body.Close()
 		out = append(out, result.Value...)
 		reqURL = result.NextLink
-	}
-	return out, nil
-}
-
-func (c *Client) listEligibleChildSubscriptions(ctx context.Context, mgID string) ([]Subscription, error) {
-	scope := fmt.Sprintf("/providers/Microsoft.Management/managementGroups/%s", url.PathEscape(mgID))
-	resources, err := c.fetchEligibleChildResources(ctx, scope)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]Subscription, 0, len(resources))
-	for _, item := range resources {
-		if !strings.Contains(strings.ToLower(item.Type), "subscription") {
-			continue
-		}
-		subID := SubscriptionIDFromScope(item.ID)
-		if subID == "" {
-			continue
-		}
-		out = append(out, Subscription{ID: subID, DisplayName: item.Name})
 	}
 	return out, nil
 }

--- a/internal/azure/discovery.go
+++ b/internal/azure/discovery.go
@@ -6,10 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
-	"path/filepath"
 	"strings"
-	"time"
 )
 
 // ListManagementGroupChildren returns the direct eligible children of a management group.
@@ -87,9 +84,6 @@ func (c *Client) fetchEligibleChildResources(ctx context.Context, scope string) 
 		}
 		resp.Body.Close()
 		out = append(out, result.Value...)
-		if os.Getenv("PIM_DEBUG_DISCOVERY") == "1" {
-			writeDiscoveryDump(scope, result.Value)
-		}
 		reqURL = result.NextLink
 	}
 	return out, nil
@@ -119,36 +113,6 @@ func (c *Client) ListEligibleResourceGroups(ctx context.Context, subscriptionID 
 		out = append(out, ResourceGroup{SubscriptionID: subscriptionID, Name: name, ID: item.ID})
 	}
 	return out, nil
-}
-
-type discoveryDump struct {
-	Scope string          `json:"scope"`
-	Value []childResource `json:"value"`
-}
-
-func writeDiscoveryDump(scope string, value []childResource) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "pim debug: home dir: %v\n", err)
-		return
-	}
-	dir := filepath.Join(home, ".config", "pim")
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		fmt.Fprintf(os.Stderr, "pim debug: mkdir %s: %v\n", dir, err)
-		return
-	}
-	name := fmt.Sprintf("eligible-child-resources-%d.json", time.Now().UnixNano())
-	path := filepath.Join(dir, name)
-	data, err := json.MarshalIndent(discoveryDump{Scope: scope, Value: value}, "", "  ")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "pim debug: marshal dump: %v\n", err)
-		return
-	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		fmt.Fprintf(os.Stderr, "pim debug: write dump: %v\n", err)
-		return
-	}
-	fmt.Fprintf(os.Stderr, "pim debug: discovery dump written to %s\n", path)
 }
 
 func displayOr(item childResource) string {

--- a/internal/azure/discovery.go
+++ b/internal/azure/discovery.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
+	"time"
 )
 
 // ListManagementGroupChildren returns the direct eligible children of a management group.
@@ -84,6 +87,9 @@ func (c *Client) fetchEligibleChildResources(ctx context.Context, scope string) 
 		}
 		resp.Body.Close()
 		out = append(out, result.Value...)
+		if os.Getenv("PIM_DEBUG_DISCOVERY") == "1" {
+			writeDiscoveryDump(scope, result.Value)
+		}
 		reqURL = result.NextLink
 	}
 	return out, nil
@@ -113,6 +119,36 @@ func (c *Client) ListEligibleResourceGroups(ctx context.Context, subscriptionID 
 		out = append(out, ResourceGroup{SubscriptionID: subscriptionID, Name: name, ID: item.ID})
 	}
 	return out, nil
+}
+
+type discoveryDump struct {
+	Scope string          `json:"scope"`
+	Value []childResource `json:"value"`
+}
+
+func writeDiscoveryDump(scope string, value []childResource) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pim debug: home dir: %v\n", err)
+		return
+	}
+	dir := filepath.Join(home, ".config", "pim")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		fmt.Fprintf(os.Stderr, "pim debug: mkdir %s: %v\n", dir, err)
+		return
+	}
+	name := fmt.Sprintf("eligible-child-resources-%d.json", time.Now().UnixNano())
+	path := filepath.Join(dir, name)
+	data, err := json.MarshalIndent(discoveryDump{Scope: scope, Value: value}, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pim debug: marshal dump: %v\n", err)
+		return
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		fmt.Fprintf(os.Stderr, "pim debug: write dump: %v\n", err)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "pim debug: discovery dump written to %s\n", path)
 }
 
 func displayOr(item childResource) string {

--- a/internal/azure/discovery.go
+++ b/internal/azure/discovery.go
@@ -9,7 +9,10 @@ import (
 	"strings"
 )
 
-// ListManagementGroupSubscriptions returns subscriptions under a management group.
+// ListManagementGroupSubscriptions returns subscriptions under a management group
+// that the caller is PIM-eligible to activate. Uses the eligibleChildResources API
+// with getAllChildren=true so nested subscriptions are included. An empty result
+// means no eligible child scopes exist, which is valid and not an error.
 func (c *Client) ListManagementGroupSubscriptions(ctx context.Context, mgID string) ([]Subscription, error) {
 	mgID = strings.TrimSpace(mgID)
 	if mgID == "" {
@@ -17,18 +20,10 @@ func (c *Client) ListManagementGroupSubscriptions(ctx context.Context, mgID stri
 	}
 
 	subs, err := c.listEligibleChildSubscriptions(ctx, mgID)
-	if err == nil && len(subs) > 0 {
-		return subs, nil
-	}
-
-	legacy, legacyErr := c.listMGSubscriptionsLegacy(ctx, mgID)
-	if legacyErr == nil {
-		return legacy, nil
-	}
 	if err != nil {
-		return nil, fmt.Errorf("eligible child resources: %w; legacy: %v", err, legacyErr)
+		return nil, err
 	}
-	return nil, legacyErr
+	return subs, nil
 }
 
 // fetchEligibleChildResources fetches PIM-eligible child resources under any
@@ -40,7 +35,7 @@ func (c *Client) fetchEligibleChildResources(ctx context.Context, scope string) 
 	if err != nil {
 		return nil, err
 	}
-	reqURL := fmt.Sprintf("%s%s/providers/Microsoft.Authorization/eligibleChildResources?api-version=%s",
+	reqURL := fmt.Sprintf("%s%s/providers/Microsoft.Authorization/eligibleChildResources?api-version=%s&$getAllChildren=true",
 		armEndpoint, scope, eligibleChildResourcesAPIVersion)
 
 	var out []childResource
@@ -110,42 +105,3 @@ func (c *Client) ListEligibleResourceGroups(ctx context.Context, subscriptionID 
 	return out, nil
 }
 
-func (c *Client) listMGSubscriptionsLegacy(ctx context.Context, mgID string) ([]Subscription, error) {
-	tok, err := c.armToken(ctx)
-	if err != nil {
-		return nil, err
-	}
-	reqURL := fmt.Sprintf("%s/providers/Microsoft.Management/managementGroups/%s/subscriptions?api-version=%s",
-		armEndpoint, url.PathEscape(mgID), managementGroupSubscriptionsAPIVersion)
-
-	var out []Subscription
-	for reqURL != "" {
-		resp, err := c.doRequest(ctx, http.MethodGet, reqURL, tok, nil)
-		if err != nil {
-			return nil, fmt.Errorf("list subscriptions for %s: %w", mgID, err)
-		}
-		var result struct {
-			Value []struct {
-				Name       string `json:"name"`
-				Properties struct {
-					DisplayName string `json:"displayName"`
-				} `json:"properties"`
-			} `json:"value"`
-			NextLink string `json:"nextLink"`
-		}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			resp.Body.Close()
-			return nil, fmt.Errorf("decode mg subscriptions: %w", err)
-		}
-		resp.Body.Close()
-		for _, item := range result.Value {
-			display := item.Properties.DisplayName
-			if strings.TrimSpace(display) == "" {
-				display = item.Name
-			}
-			out = append(out, Subscription{ID: item.Name, DisplayName: display})
-		}
-		reqURL = result.NextLink
-	}
-	return out, nil
-}

--- a/internal/azure/discovery.go
+++ b/internal/azure/discovery.go
@@ -104,4 +104,3 @@ func (c *Client) ListEligibleResourceGroups(ctx context.Context, subscriptionID 
 	}
 	return out, nil
 }
-

--- a/internal/azure/discovery.go
+++ b/internal/azure/discovery.go
@@ -33,32 +33,18 @@ func classifyChildResources(resources []childResource) ([]ManagementGroup, []Sub
 	for _, item := range resources {
 		lower := strings.ToLower(item.Type)
 		switch {
-		case strings.HasSuffix(lower, "/resourcegroups"):
-			// never a direct child of an MG
-		case strings.HasSuffix(lower, "/managementgroups"):
-			if countSegments(item.ID) == 4 {
-				mgs = append(mgs, ManagementGroup{ID: item.Name, DisplayName: displayOr(item)})
-			}
-		case strings.HasSuffix(lower, "/subscriptions"):
-			if countSegments(item.ID) == 2 {
-				subID := SubscriptionIDFromScope(item.ID)
-				if subID != "" {
-					subs = append(subs, Subscription{ID: subID, DisplayName: displayOr(item)})
-				}
+		case strings.Contains(lower, "resourcegroup"):
+			// not an MG-level child; skip
+		case strings.Contains(lower, "managementgroup"):
+			mgs = append(mgs, ManagementGroup{ID: item.Name, DisplayName: displayOr(item)})
+		case strings.Contains(lower, "subscription"):
+			subID := SubscriptionIDFromScope(item.ID)
+			if subID != "" {
+				subs = append(subs, Subscription{ID: subID, DisplayName: displayOr(item)})
 			}
 		}
 	}
 	return mgs, subs
-}
-
-func countSegments(path string) int {
-	n := 0
-	for _, s := range strings.Split(path, "/") {
-		if s != "" {
-			n++
-		}
-	}
-	return n
 }
 
 // ListManagementGroupSubscriptions returns subscriptions under a management group

--- a/internal/azure/discovery.go
+++ b/internal/azure/discovery.go
@@ -23,23 +23,42 @@ func (c *Client) ListManagementGroupChildren(ctx context.Context, mgID string) (
 		return nil, nil, err
 	}
 
+	mgs, subs := classifyChildResources(resources)
+	return mgs, subs, nil
+}
+
+func classifyChildResources(resources []childResource) ([]ManagementGroup, []Subscription) {
 	var mgs []ManagementGroup
 	var subs []Subscription
 	for _, item := range resources {
 		lower := strings.ToLower(item.Type)
 		switch {
 		case strings.HasSuffix(lower, "/resourcegroups"):
-			// not a direct child of an MG; ignore
+			// never a direct child of an MG
 		case strings.HasSuffix(lower, "/managementgroups"):
-			mgs = append(mgs, ManagementGroup{ID: item.Name, DisplayName: displayOr(item)})
+			if countSegments(item.ID) == 4 {
+				mgs = append(mgs, ManagementGroup{ID: item.Name, DisplayName: displayOr(item)})
+			}
 		case strings.HasSuffix(lower, "/subscriptions"):
-			subID := SubscriptionIDFromScope(item.ID)
-			if subID != "" {
-				subs = append(subs, Subscription{ID: subID, DisplayName: displayOr(item)})
+			if countSegments(item.ID) == 2 {
+				subID := SubscriptionIDFromScope(item.ID)
+				if subID != "" {
+					subs = append(subs, Subscription{ID: subID, DisplayName: displayOr(item)})
+				}
 			}
 		}
 	}
-	return mgs, subs, nil
+	return mgs, subs
+}
+
+func countSegments(path string) int {
+	n := 0
+	for _, s := range strings.Split(path, "/") {
+		if s != "" {
+			n++
+		}
+	}
+	return n
 }
 
 // ListManagementGroupSubscriptions returns subscriptions under a management group
@@ -60,7 +79,7 @@ func (c *Client) fetchEligibleChildResources(ctx context.Context, scope string) 
 	if err != nil {
 		return nil, err
 	}
-	reqURL := fmt.Sprintf("%s%s/providers/Microsoft.Authorization/eligibleChildResources?api-version=%s",
+	reqURL := fmt.Sprintf("%s%s/providers/Microsoft.Authorization/eligibleChildResources?api-version=%s&$getAllChildren=true",
 		armEndpoint, scope, eligibleChildResourcesAPIVersion)
 
 	var out []childResource

--- a/internal/azure/discovery_test.go
+++ b/internal/azure/discovery_test.go
@@ -16,15 +16,15 @@ func TestClassifyChildResourcesBareTypes(t *testing.T) {
 			}{DisplayName: "Child MG"},
 		},
 		{
-			ID:   "/subscriptions/00000000-0000-0000-0000-000000000001",
-			Name: "00000000-0000-0000-0000-000000000001",
+			ID:   "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Name: "00000000-0000-0000-0000-000000000000",
 			Type: "subscription",
 			Properties: struct {
 				DisplayName string `json:"displayName"`
 			}{DisplayName: "My Sub"},
 		},
 		{
-			ID:   "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/my-rg",
+			ID:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg",
 			Name: "my-rg",
 			Type: "resourcegroup",
 		},
@@ -58,15 +58,15 @@ func TestClassifyChildResourcesNamespacedTypes(t *testing.T) {
 			}{DisplayName: "Child MG"},
 		},
 		{
-			ID:   "/subscriptions/00000000-0000-0000-0000-000000000001",
-			Name: "00000000-0000-0000-0000-000000000001",
+			ID:   "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Name: "00000000-0000-0000-0000-000000000000",
 			Type: "Microsoft.Resources/subscriptions",
 			Properties: struct {
 				DisplayName string `json:"displayName"`
 			}{DisplayName: "My Sub"},
 		},
 		{
-			ID:   "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/my-rg",
+			ID:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg",
 			Name: "my-rg",
 			Type: "Microsoft.Resources/subscriptions/resourceGroups",
 		},

--- a/internal/azure/discovery_test.go
+++ b/internal/azure/discovery_test.go
@@ -1,8 +1,61 @@
 package azure
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// TestWriteDiscoveryDump verifies that writeDiscoveryDump creates a 0600 JSON file
+// containing scope and value when PIM_DEBUG_DISCOVERY=1.
+func TestWriteDiscoveryDump(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	resources := []childResource{
+		{ID: "/subscriptions/abc", Name: "abc", Type: "subscription"},
+	}
+	writeDiscoveryDump("/subscriptions/abc", resources)
+
+	entries, err := os.ReadDir(filepath.Join(dir, ".config", "pim"))
+	if err != nil {
+		t.Fatalf("config dir not created: %v", err)
+	}
+	var dumpFile string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "eligible-child-resources-") && strings.HasSuffix(e.Name(), ".json") {
+			dumpFile = filepath.Join(dir, ".config", "pim", e.Name())
+		}
+	}
+	if dumpFile == "" {
+		t.Fatal("no dump file written")
+	}
+
+	info, err := os.Stat(dumpFile)
+	if err != nil {
+		t.Fatalf("stat dump file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("expected 0600 permissions, got %04o", perm)
+	}
+
+	raw, err := os.ReadFile(dumpFile)
+	if err != nil {
+		t.Fatalf("read dump file: %v", err)
+	}
+	var dump discoveryDump
+	if err := json.Unmarshal(raw, &dump); err != nil {
+		t.Fatalf("unmarshal dump: %v", err)
+	}
+	if dump.Scope != "/subscriptions/abc" {
+		t.Errorf("unexpected scope %q", dump.Scope)
+	}
+	if len(dump.Value) != 1 || dump.Value[0].Name != "abc" {
+		t.Errorf("unexpected value %+v", dump.Value)
+	}
+}
 
 // TestClassifyChildResourcesBareTypes verifies the real PIM API type shapes (bare strings).
 func TestClassifyChildResourcesBareTypes(t *testing.T) {

--- a/internal/azure/discovery_test.go
+++ b/internal/azure/discovery_test.go
@@ -1,7 +1,6 @@
 package azure
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -30,22 +29,7 @@ func TestListManagementGroupChildrenTypeClassification(t *testing.T) {
 		},
 	}
 
-	var mgs []ManagementGroup
-	var subs []Subscription
-	for _, item := range resources {
-		lower := strings.ToLower(item.Type)
-		switch {
-		case strings.HasSuffix(lower, "/resourcegroups"):
-			// not a direct child of an MG; ignore
-		case strings.HasSuffix(lower, "/managementgroups"):
-			mgs = append(mgs, ManagementGroup{ID: item.Name, DisplayName: displayOr(item)})
-		case strings.HasSuffix(lower, "/subscriptions"):
-			subID := SubscriptionIDFromScope(item.ID)
-			if subID != "" {
-				subs = append(subs, Subscription{ID: subID, DisplayName: displayOr(item)})
-			}
-		}
-	}
+	mgs, subs := classifyChildResources(resources)
 
 	if len(mgs) != 1 {
 		t.Fatalf("expected 1 management group, got %d", len(mgs))
@@ -58,5 +42,83 @@ func TestListManagementGroupChildrenTypeClassification(t *testing.T) {
 	}
 	if subs[0].DisplayName != "My Sub" {
 		t.Errorf("expected display name 'My Sub', got %q", subs[0].DisplayName)
+	}
+}
+
+func TestListManagementGroupChildrenFiltersDeepDescendants(t *testing.T) {
+	resources := []childResource{
+		// direct child MG (4 segments: /providers/Microsoft.Management/managementGroups/<id>) — keep
+		{
+			ID:   "/providers/Microsoft.Management/managementGroups/direct-mg",
+			Name: "direct-mg",
+			Type: "Microsoft.Management/managementGroups",
+			Properties: struct {
+				DisplayName string `json:"displayName"`
+			}{DisplayName: "Direct MG"},
+		},
+		// nested grandchild MG (would be same 5 segments — MG IDs are always flat)
+		// Azure returns nested MGs with the same 5-segment shape; depth is encoded in
+		// the hierarchy, not the ID. The segment filter correctly passes all MG IDs.
+		// Test that a malformed/unexpected deep path is excluded:
+		{
+			ID:   "/providers/Microsoft.Management/managementGroups/parent/children/nested-mg",
+			Name: "nested-mg",
+			Type: "Microsoft.Management/managementGroups",
+			Properties: struct {
+				DisplayName string `json:"displayName"`
+			}{DisplayName: "Nested MG"},
+		},
+		// direct child subscription (2 segments) — keep
+		{
+			ID:   "/subscriptions/aaaaaaaa-0000-0000-0000-000000000001",
+			Name: "aaaaaaaa-0000-0000-0000-000000000001",
+			Type: "Microsoft.Resources/subscriptions",
+			Properties: struct {
+				DisplayName string `json:"displayName"`
+			}{DisplayName: "Direct Sub"},
+		},
+		// subscription nested under a resource group path (>2 segments) — exclude
+		{
+			ID:   "/subscriptions/bbbbbbbb-0000-0000-0000-000000000002/resourceGroups/rg1",
+			Name: "bbbbbbbb-0000-0000-0000-000000000002",
+			Type: "Microsoft.Resources/subscriptions",
+			Properties: struct {
+				DisplayName string `json:"displayName"`
+			}{DisplayName: "Deep Sub"},
+		},
+	}
+
+	mgs, subs := classifyChildResources(resources)
+
+	if len(mgs) != 1 {
+		t.Fatalf("expected 1 management group after depth filter, got %d", len(mgs))
+	}
+	if mgs[0].DisplayName != "Direct MG" {
+		t.Errorf("expected 'Direct MG', got %q", mgs[0].DisplayName)
+	}
+	if len(subs) != 1 {
+		t.Fatalf("expected 1 subscription after depth filter, got %d", len(subs))
+	}
+	if subs[0].DisplayName != "Direct Sub" {
+		t.Errorf("expected 'Direct Sub', got %q", subs[0].DisplayName)
+	}
+}
+
+func TestCountSegments(t *testing.T) {
+	cases := []struct {
+		path string
+		want int
+	}{
+		{"/subscriptions/abc", 2},
+		{"/providers/Microsoft.Management/managementGroups/root", 4},
+		{"/subscriptions/abc/resourceGroups/rg1", 4},
+		{"", 0},
+		{"/", 0},
+	}
+	for _, tc := range cases {
+		got := countSegments(tc.path)
+		if got != tc.want {
+			t.Errorf("countSegments(%q) = %d, want %d", tc.path, got, tc.want)
+		}
 	}
 }

--- a/internal/azure/discovery_test.go
+++ b/internal/azure/discovery_test.go
@@ -1,61 +1,8 @@
 package azure
 
 import (
-	"encoding/json"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 )
-
-// TestWriteDiscoveryDump verifies that writeDiscoveryDump creates a 0600 JSON file
-// containing scope and value when PIM_DEBUG_DISCOVERY=1.
-func TestWriteDiscoveryDump(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
-
-	resources := []childResource{
-		{ID: "/subscriptions/abc", Name: "abc", Type: "subscription"},
-	}
-	writeDiscoveryDump("/subscriptions/abc", resources)
-
-	entries, err := os.ReadDir(filepath.Join(dir, ".config", "pim"))
-	if err != nil {
-		t.Fatalf("config dir not created: %v", err)
-	}
-	var dumpFile string
-	for _, e := range entries {
-		if strings.HasPrefix(e.Name(), "eligible-child-resources-") && strings.HasSuffix(e.Name(), ".json") {
-			dumpFile = filepath.Join(dir, ".config", "pim", e.Name())
-		}
-	}
-	if dumpFile == "" {
-		t.Fatal("no dump file written")
-	}
-
-	info, err := os.Stat(dumpFile)
-	if err != nil {
-		t.Fatalf("stat dump file: %v", err)
-	}
-	if perm := info.Mode().Perm(); perm != 0o600 {
-		t.Errorf("expected 0600 permissions, got %04o", perm)
-	}
-
-	raw, err := os.ReadFile(dumpFile)
-	if err != nil {
-		t.Fatalf("read dump file: %v", err)
-	}
-	var dump discoveryDump
-	if err := json.Unmarshal(raw, &dump); err != nil {
-		t.Fatalf("unmarshal dump: %v", err)
-	}
-	if dump.Scope != "/subscriptions/abc" {
-		t.Errorf("unexpected scope %q", dump.Scope)
-	}
-	if len(dump.Value) != 1 || dump.Value[0].Name != "abc" {
-		t.Errorf("unexpected value %+v", dump.Value)
-	}
-}
 
 // TestClassifyChildResourcesBareTypes verifies the real PIM API type shapes (bare strings).
 func TestClassifyChildResourcesBareTypes(t *testing.T) {

--- a/internal/azure/discovery_test.go
+++ b/internal/azure/discovery_test.go
@@ -4,7 +4,50 @@ import (
 	"testing"
 )
 
-func TestListManagementGroupChildrenTypeClassification(t *testing.T) {
+// TestClassifyChildResourcesBareTypes verifies the real PIM API type shapes (bare strings).
+func TestClassifyChildResourcesBareTypes(t *testing.T) {
+	resources := []childResource{
+		{
+			ID:   "/providers/Microsoft.Management/managementGroups/child-mg",
+			Name: "child-mg",
+			Type: "managementgroup",
+			Properties: struct {
+				DisplayName string `json:"displayName"`
+			}{DisplayName: "Child MG"},
+		},
+		{
+			ID:   "/subscriptions/00000000-0000-0000-0000-000000000001",
+			Name: "00000000-0000-0000-0000-000000000001",
+			Type: "subscription",
+			Properties: struct {
+				DisplayName string `json:"displayName"`
+			}{DisplayName: "My Sub"},
+		},
+		{
+			ID:   "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/my-rg",
+			Name: "my-rg",
+			Type: "resourcegroup",
+		},
+	}
+
+	mgs, subs := classifyChildResources(resources)
+
+	if len(mgs) != 1 {
+		t.Fatalf("expected 1 management group, got %d", len(mgs))
+	}
+	if mgs[0].DisplayName != "Child MG" {
+		t.Errorf("expected display name 'Child MG', got %q", mgs[0].DisplayName)
+	}
+	if len(subs) != 1 {
+		t.Fatalf("expected 1 subscription, got %d", len(subs))
+	}
+	if subs[0].DisplayName != "My Sub" {
+		t.Errorf("expected display name 'My Sub', got %q", subs[0].DisplayName)
+	}
+}
+
+// TestClassifyChildResourcesNamespacedTypes verifies namespace-prefixed type strings also work.
+func TestClassifyChildResourcesNamespacedTypes(t *testing.T) {
 	resources := []childResource{
 		{
 			ID:   "/providers/Microsoft.Management/managementGroups/child-mg",
@@ -34,91 +77,19 @@ func TestListManagementGroupChildrenTypeClassification(t *testing.T) {
 	if len(mgs) != 1 {
 		t.Fatalf("expected 1 management group, got %d", len(mgs))
 	}
-	if mgs[0].DisplayName != "Child MG" {
-		t.Errorf("expected display name 'Child MG', got %q", mgs[0].DisplayName)
-	}
 	if len(subs) != 1 {
-		t.Fatalf("expected 1 subscription, got %d", len(subs))
-	}
-	if subs[0].DisplayName != "My Sub" {
-		t.Errorf("expected display name 'My Sub', got %q", subs[0].DisplayName)
+		t.Fatalf("expected 1 subscription, got %d: %+v", len(subs), subs)
 	}
 }
 
-func TestListManagementGroupChildrenFiltersDeepDescendants(t *testing.T) {
+// TestClassifyChildResourcesRGsSkipped verifies resource groups are always skipped.
+func TestClassifyChildResourcesRGsSkipped(t *testing.T) {
 	resources := []childResource{
-		// direct child MG (4 segments: /providers/Microsoft.Management/managementGroups/<id>) — keep
-		{
-			ID:   "/providers/Microsoft.Management/managementGroups/direct-mg",
-			Name: "direct-mg",
-			Type: "Microsoft.Management/managementGroups",
-			Properties: struct {
-				DisplayName string `json:"displayName"`
-			}{DisplayName: "Direct MG"},
-		},
-		// nested grandchild MG (would be same 5 segments — MG IDs are always flat)
-		// Azure returns nested MGs with the same 5-segment shape; depth is encoded in
-		// the hierarchy, not the ID. The segment filter correctly passes all MG IDs.
-		// Test that a malformed/unexpected deep path is excluded:
-		{
-			ID:   "/providers/Microsoft.Management/managementGroups/parent/children/nested-mg",
-			Name: "nested-mg",
-			Type: "Microsoft.Management/managementGroups",
-			Properties: struct {
-				DisplayName string `json:"displayName"`
-			}{DisplayName: "Nested MG"},
-		},
-		// direct child subscription (2 segments) — keep
-		{
-			ID:   "/subscriptions/aaaaaaaa-0000-0000-0000-000000000001",
-			Name: "aaaaaaaa-0000-0000-0000-000000000001",
-			Type: "Microsoft.Resources/subscriptions",
-			Properties: struct {
-				DisplayName string `json:"displayName"`
-			}{DisplayName: "Direct Sub"},
-		},
-		// subscription nested under a resource group path (>2 segments) — exclude
-		{
-			ID:   "/subscriptions/bbbbbbbb-0000-0000-0000-000000000002/resourceGroups/rg1",
-			Name: "bbbbbbbb-0000-0000-0000-000000000002",
-			Type: "Microsoft.Resources/subscriptions",
-			Properties: struct {
-				DisplayName string `json:"displayName"`
-			}{DisplayName: "Deep Sub"},
-		},
+		{ID: "/subscriptions/aaa/resourceGroups/rg1", Name: "rg1", Type: "resourcegroup"},
+		{ID: "/subscriptions/aaa/resourceGroups/rg2", Name: "rg2", Type: "Microsoft.Resources/subscriptions/resourceGroups"},
 	}
-
 	mgs, subs := classifyChildResources(resources)
-
-	if len(mgs) != 1 {
-		t.Fatalf("expected 1 management group after depth filter, got %d", len(mgs))
-	}
-	if mgs[0].DisplayName != "Direct MG" {
-		t.Errorf("expected 'Direct MG', got %q", mgs[0].DisplayName)
-	}
-	if len(subs) != 1 {
-		t.Fatalf("expected 1 subscription after depth filter, got %d", len(subs))
-	}
-	if subs[0].DisplayName != "Direct Sub" {
-		t.Errorf("expected 'Direct Sub', got %q", subs[0].DisplayName)
-	}
-}
-
-func TestCountSegments(t *testing.T) {
-	cases := []struct {
-		path string
-		want int
-	}{
-		{"/subscriptions/abc", 2},
-		{"/providers/Microsoft.Management/managementGroups/root", 4},
-		{"/subscriptions/abc/resourceGroups/rg1", 4},
-		{"", 0},
-		{"/", 0},
-	}
-	for _, tc := range cases {
-		got := countSegments(tc.path)
-		if got != tc.want {
-			t.Errorf("countSegments(%q) = %d, want %d", tc.path, got, tc.want)
-		}
+	if len(mgs) != 0 || len(subs) != 0 {
+		t.Fatalf("expected no results, got mgs=%d subs=%d", len(mgs), len(subs))
 	}
 }

--- a/internal/azure/discovery_test.go
+++ b/internal/azure/discovery_test.go
@@ -1,0 +1,62 @@
+package azure
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestListManagementGroupChildrenTypeClassification(t *testing.T) {
+	resources := []childResource{
+		{
+			ID:   "/providers/Microsoft.Management/managementGroups/child-mg",
+			Name: "child-mg",
+			Type: "Microsoft.Management/managementGroups",
+			Properties: struct {
+				DisplayName string `json:"displayName"`
+			}{DisplayName: "Child MG"},
+		},
+		{
+			ID:   "/subscriptions/00000000-0000-0000-0000-000000000001",
+			Name: "00000000-0000-0000-0000-000000000001",
+			Type: "Microsoft.Resources/subscriptions",
+			Properties: struct {
+				DisplayName string `json:"displayName"`
+			}{DisplayName: "My Sub"},
+		},
+		{
+			ID:   "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/my-rg",
+			Name: "my-rg",
+			Type: "Microsoft.Resources/subscriptions/resourceGroups",
+		},
+	}
+
+	var mgs []ManagementGroup
+	var subs []Subscription
+	for _, item := range resources {
+		lower := strings.ToLower(item.Type)
+		switch {
+		case strings.HasSuffix(lower, "/resourcegroups"):
+			// not a direct child of an MG; ignore
+		case strings.HasSuffix(lower, "/managementgroups"):
+			mgs = append(mgs, ManagementGroup{ID: item.Name, DisplayName: displayOr(item)})
+		case strings.HasSuffix(lower, "/subscriptions"):
+			subID := SubscriptionIDFromScope(item.ID)
+			if subID != "" {
+				subs = append(subs, Subscription{ID: subID, DisplayName: displayOr(item)})
+			}
+		}
+	}
+
+	if len(mgs) != 1 {
+		t.Fatalf("expected 1 management group, got %d", len(mgs))
+	}
+	if mgs[0].DisplayName != "Child MG" {
+		t.Errorf("expected display name 'Child MG', got %q", mgs[0].DisplayName)
+	}
+	if len(subs) != 1 {
+		t.Fatalf("expected 1 subscription, got %d", len(subs))
+	}
+	if subs[0].DisplayName != "My Sub" {
+		t.Errorf("expected display name 'My Sub', got %q", subs[0].DisplayName)
+	}
+}

--- a/internal/azure/scopes.go
+++ b/internal/azure/scopes.go
@@ -108,14 +108,36 @@ func ScopeIsChildOf(child, parent string) bool {
 	return c == p || strings.HasPrefix(c, p+"/")
 }
 
+var reGUID = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// ExpandScopeFilter normalizes a user-supplied scope filter to an ARM path when
+// the input looks like a bare subscription GUID or a bare management-group name
+// (no slashes). ARM paths are returned unchanged.
+//
+// Returns the expanded path and whether expansion occurred. Callers should
+// prefer the expanded path for ARM matching but fall back to the original for
+// display-name substring matching.
+func ExpandScopeFilter(filter string) (expanded string, wasExpanded bool) {
+	f := strings.TrimSpace(filter)
+	if f == "" || strings.Contains(f, "/") {
+		return f, false
+	}
+	if reGUID.MatchString(f) {
+		return "/subscriptions/" + f, true
+	}
+	return "/providers/Microsoft.Management/managementGroups/" + f, true
+}
+
 // ScopeMatches reports whether filter matches a role's scope, using ARM child-path
-// check first, then case-insensitive substring match on scopeDisplay and scope.
+// check first (with bare-GUID/MG-name expansion), then case-insensitive substring
+// match on scopeDisplay and scope.
 func ScopeMatches(filter, scope, scopeDisplay string) bool {
 	f := strings.TrimSpace(filter)
 	if f == "" {
 		return false
 	}
-	if ScopeIsChildOf(f, scope) {
+	expanded, _ := ExpandScopeFilter(f)
+	if ScopeIsChildOf(expanded, scope) {
 		return true
 	}
 	lower := strings.ToLower(f)

--- a/internal/azure/scopes_test.go
+++ b/internal/azure/scopes_test.go
@@ -17,8 +17,8 @@ func TestExpandScopeFilter(t *testing.T) {
 		},
 		{
 			name:        "bare MG name expands",
-			input:       "Omnia",
-			wantExp:     "/providers/Microsoft.Management/managementGroups/Omnia",
+			input:       "Contoso",
+			wantExp:     "/providers/Microsoft.Management/managementGroups/Contoso",
 			wantChanged: true,
 		},
 		{
@@ -69,10 +69,10 @@ func TestScopeMatchesBareGUID(t *testing.T) {
 }
 
 func TestScopeMatchesBareMGName(t *testing.T) {
-	scope := "/providers/Microsoft.Management/managementGroups/Omnia"
-	display := "Omnia"
+	scope := "/providers/Microsoft.Management/managementGroups/Contoso"
+	display := "Contoso"
 
-	if !ScopeMatches("Omnia", scope, display) {
+	if !ScopeMatches("Contoso", scope, display) {
 		t.Error("ScopeMatches: bare MG name should match MG scope")
 	}
 	if ScopeMatches("OtherMG", scope, display) {

--- a/internal/azure/scopes_test.go
+++ b/internal/azure/scopes_test.go
@@ -1,0 +1,81 @@
+package azure
+
+import "testing"
+
+func TestExpandScopeFilter(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantExp     string
+		wantChanged bool
+	}{
+		{
+			name:        "bare subscription GUID expands",
+			input:       "e14cf978-da6b-4661-86b4-f02acd680147",
+			wantExp:     "/subscriptions/e14cf978-da6b-4661-86b4-f02acd680147",
+			wantChanged: true,
+		},
+		{
+			name:        "bare MG name expands",
+			input:       "Omnia",
+			wantExp:     "/providers/Microsoft.Management/managementGroups/Omnia",
+			wantChanged: true,
+		},
+		{
+			name:        "ARM subscription path unchanged",
+			input:       "/subscriptions/e14cf978-da6b-4661-86b4-f02acd680147",
+			wantExp:     "/subscriptions/e14cf978-da6b-4661-86b4-f02acd680147",
+			wantChanged: false,
+		},
+		{
+			name:        "ARM MG path unchanged",
+			input:       "/providers/Microsoft.Management/managementGroups/root",
+			wantExp:     "/providers/Microsoft.Management/managementGroups/root",
+			wantChanged: false,
+		},
+		{
+			name:        "empty string unchanged",
+			input:       "",
+			wantExp:     "",
+			wantChanged: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, changed := ExpandScopeFilter(tt.input)
+			if got != tt.wantExp {
+				t.Errorf("ExpandScopeFilter(%q) expanded = %q; want %q", tt.input, got, tt.wantExp)
+			}
+			if changed != tt.wantChanged {
+				t.Errorf("ExpandScopeFilter(%q) wasExpanded = %v; want %v", tt.input, changed, tt.wantChanged)
+			}
+		})
+	}
+}
+
+func TestScopeMatchesBareGUID(t *testing.T) {
+	scope := "/subscriptions/e14cf978-da6b-4661-86b4-f02acd680147"
+	display := "My Subscription"
+
+	if !ScopeMatches("e14cf978-da6b-4661-86b4-f02acd680147", scope, display) {
+		t.Error("ScopeMatches: bare GUID should match subscription scope")
+	}
+	if !ScopeMatches(scope, scope, display) {
+		t.Error("ScopeMatches: ARM path should match itself")
+	}
+	if ScopeMatches("e14cf978-da6b-4661-86b4-f02acd680147", "/subscriptions/other-guid", "Other") {
+		t.Error("ScopeMatches: bare GUID should not match different subscription")
+	}
+}
+
+func TestScopeMatchesBareMGName(t *testing.T) {
+	scope := "/providers/Microsoft.Management/managementGroups/Omnia"
+	display := "Omnia"
+
+	if !ScopeMatches("Omnia", scope, display) {
+		t.Error("ScopeMatches: bare MG name should match MG scope")
+	}
+	if ScopeMatches("OtherMG", scope, display) {
+		t.Error("ScopeMatches: bare MG name should not match different MG scope")
+	}
+}

--- a/internal/azure/scopes_test.go
+++ b/internal/azure/scopes_test.go
@@ -11,8 +11,8 @@ func TestExpandScopeFilter(t *testing.T) {
 	}{
 		{
 			name:        "bare subscription GUID expands",
-			input:       "e14cf978-da6b-4661-86b4-f02acd680147",
-			wantExp:     "/subscriptions/e14cf978-da6b-4661-86b4-f02acd680147",
+			input:       "00000000-0000-0000-0000-000000000000",
+			wantExp:     "/subscriptions/00000000-0000-0000-0000-000000000000",
 			wantChanged: true,
 		},
 		{
@@ -23,8 +23,8 @@ func TestExpandScopeFilter(t *testing.T) {
 		},
 		{
 			name:        "ARM subscription path unchanged",
-			input:       "/subscriptions/e14cf978-da6b-4661-86b4-f02acd680147",
-			wantExp:     "/subscriptions/e14cf978-da6b-4661-86b4-f02acd680147",
+			input:       "/subscriptions/00000000-0000-0000-0000-000000000000",
+			wantExp:     "/subscriptions/00000000-0000-0000-0000-000000000000",
 			wantChanged: false,
 		},
 		{
@@ -54,16 +54,16 @@ func TestExpandScopeFilter(t *testing.T) {
 }
 
 func TestScopeMatchesBareGUID(t *testing.T) {
-	scope := "/subscriptions/e14cf978-da6b-4661-86b4-f02acd680147"
+	scope := "/subscriptions/00000000-0000-0000-0000-000000000000"
 	display := "My Subscription"
 
-	if !ScopeMatches("e14cf978-da6b-4661-86b4-f02acd680147", scope, display) {
+	if !ScopeMatches("00000000-0000-0000-0000-000000000000", scope, display) {
 		t.Error("ScopeMatches: bare GUID should match subscription scope")
 	}
 	if !ScopeMatches(scope, scope, display) {
 		t.Error("ScopeMatches: ARM path should match itself")
 	}
-	if ScopeMatches("e14cf978-da6b-4661-86b4-f02acd680147", "/subscriptions/other-guid", "Other") {
+	if ScopeMatches("00000000-0000-0000-0000-000000000000", "/subscriptions/other-guid", "Other") {
 		t.Error("ScopeMatches: bare GUID should not match different subscription")
 	}
 }

--- a/internal/azure/scopes_test.go
+++ b/internal/azure/scopes_test.go
@@ -17,8 +17,8 @@ func TestExpandScopeFilter(t *testing.T) {
 		},
 		{
 			name:        "bare MG name expands",
-			input:       "Contoso",
-			wantExp:     "/providers/Microsoft.Management/managementGroups/Contoso",
+			input:       "example-mg",
+			wantExp:     "/providers/Microsoft.Management/managementGroups/example-mg",
 			wantChanged: true,
 		},
 		{
@@ -69,10 +69,10 @@ func TestScopeMatchesBareGUID(t *testing.T) {
 }
 
 func TestScopeMatchesBareMGName(t *testing.T) {
-	scope := "/providers/Microsoft.Management/managementGroups/Contoso"
-	display := "Contoso"
+	scope := "/providers/Microsoft.Management/managementGroups/example-mg"
+	display := "example-mg"
 
-	if !ScopeMatches("Contoso", scope, display) {
+	if !ScopeMatches("example-mg", scope, display) {
 		t.Error("ScopeMatches: bare MG name should match MG scope")
 	}
 	if ScopeMatches("OtherMG", scope, display) {

--- a/internal/azure/types.go
+++ b/internal/azure/types.go
@@ -22,6 +22,17 @@ type Role struct {
 	EligibilityScheduleID string
 }
 
+// ManagementGroup represents an Azure management group.
+type ManagementGroup struct {
+	ID          string
+	DisplayName string
+}
+
+// Scope returns the ARM scope path for the management group.
+func (mg ManagementGroup) Scope() string {
+	return "/providers/Microsoft.Management/managementGroups/" + mg.ID
+}
+
 // ScopeType classifies the scope level.
 type ScopeType int
 

--- a/internal/headless/run.go
+++ b/internal/headless/run.go
@@ -195,15 +195,16 @@ func filterRoles(roles []azure.Role, roleFilters, scopeFilters []string) ([]role
 
 	var out []roleTarget
 	for _, sf := range scopeFilters {
+		expanded, _ := azure.ExpandScopeFilter(sf)
 		armMatches := map[int]struct{}{}
 		for _, i := range roleIdx {
-			if azure.ScopeIsChildOf(sf, roles[i].Scope) {
+			if azure.ScopeIsChildOf(expanded, roles[i].Scope) {
 				armMatches[i] = struct{}{}
 			}
 		}
 		if len(armMatches) > 0 {
 			for i := range armMatches {
-				out = append(out, roleTarget{role: roles[i], scope: sf})
+				out = append(out, roleTarget{role: roles[i], scope: expanded})
 			}
 			continue
 		}
@@ -262,7 +263,8 @@ func filterAssignments(assignments []azure.ActiveAssignment, roleFilters, scopeF
 		if len(scopeFilters) > 0 {
 			scopeMatch := false
 			for _, sf := range scopeFilters {
-				if azure.ScopeIsChildOf(a.Scope, sf) || azure.ScopeIsChildOf(sf, a.Scope) {
+				expanded, _ := azure.ExpandScopeFilter(sf)
+				if azure.ScopeIsChildOf(a.Scope, expanded) || azure.ScopeIsChildOf(expanded, a.Scope) {
 					scopeMatch = true
 					break
 				}

--- a/internal/headless/run.go
+++ b/internal/headless/run.go
@@ -225,12 +225,6 @@ func filterRoles(roles []azure.Role, roleFilters, scopeFilters []string) ([]role
 	return out, nil
 }
 
-// scopeIsChildOf reports whether child is equal to or a descendant of parent.
-// Both are ARM scope paths (case-insensitive prefix match on path segments).
-func scopeIsChildOf(child, parent string) bool {
-	return azure.ScopeIsChildOf(child, parent)
-}
-
 func filterAssignments(assignments []azure.ActiveAssignment, roleFilters, scopeFilters []string) ([]azure.ActiveAssignment, error) {
 	if len(roleFilters) == 0 && len(scopeFilters) == 0 {
 		return assignments, nil

--- a/internal/headless/run_test.go
+++ b/internal/headless/run_test.go
@@ -381,7 +381,7 @@ func TestRunStatusJSONValid(t *testing.T) {
 }
 
 func TestFilterRolesBareGUID(t *testing.T) {
-	const guid = "e14cf978-da6b-4661-86b4-f02acd680147"
+	const guid = "00000000-0000-0000-0000-000000000000"
 	roles := []azure.Role{
 		{RoleName: "Owner", Scope: "/subscriptions/" + guid, ScopeDisplay: "My Sub"},
 		{RoleName: "Owner", Scope: "/subscriptions/other-sub", ScopeDisplay: "Other Sub"},
@@ -404,7 +404,7 @@ func TestFilterRolesBareGUID(t *testing.T) {
 }
 
 func TestFilterAssignmentsBareGUID(t *testing.T) {
-	const guid = "e14cf978-da6b-4661-86b4-f02acd680147"
+	const guid = "00000000-0000-0000-0000-000000000000"
 	assignments := []azure.ActiveAssignment{
 		{RoleName: "Owner", Scope: "/subscriptions/" + guid, ScopeDisplay: "My Sub"},
 		{RoleName: "Owner", Scope: "/subscriptions/other-sub", ScopeDisplay: "Other Sub"},

--- a/internal/headless/run_test.go
+++ b/internal/headless/run_test.go
@@ -379,3 +379,45 @@ func TestRunStatusJSONValid(t *testing.T) {
 		t.Errorf("want 1 element, got %d", len(result))
 	}
 }
+
+func TestFilterRolesBareGUID(t *testing.T) {
+	const guid = "e14cf978-da6b-4661-86b4-f02acd680147"
+	roles := []azure.Role{
+		{RoleName: "Owner", Scope: "/subscriptions/" + guid, ScopeDisplay: "My Sub"},
+		{RoleName: "Owner", Scope: "/subscriptions/other-sub", ScopeDisplay: "Other Sub"},
+	}
+
+	targets, err := filterRoles(roles, []string{"Owner"}, []string{guid})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	wantScope := "/subscriptions/" + guid
+	if targets[0].scope != wantScope {
+		t.Errorf("target scope = %q; want %q", targets[0].scope, wantScope)
+	}
+	if targets[0].role.Scope != "/subscriptions/"+guid {
+		t.Errorf("role scope = %q; want /subscriptions/%s", targets[0].role.Scope, guid)
+	}
+}
+
+func TestFilterAssignmentsBareGUID(t *testing.T) {
+	const guid = "e14cf978-da6b-4661-86b4-f02acd680147"
+	assignments := []azure.ActiveAssignment{
+		{RoleName: "Owner", Scope: "/subscriptions/" + guid, ScopeDisplay: "My Sub"},
+		{RoleName: "Owner", Scope: "/subscriptions/other-sub", ScopeDisplay: "Other Sub"},
+	}
+
+	out, err := filterAssignments(assignments, []string{"Owner"}, []string{guid})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("want 1 assignment, got %d", len(out))
+	}
+	if out[0].Scope != "/subscriptions/"+guid {
+		t.Errorf("assignment scope = %q; want /subscriptions/%s", out[0].Scope, guid)
+	}
+}

--- a/internal/tui/activate/rolelist_test.go
+++ b/internal/tui/activate/rolelist_test.go
@@ -10,6 +10,7 @@ func TestAutoAdvance(t *testing.T) {
 	roleA := azure.Role{RoleName: "Contributor", Scope: "/subscriptions/sub-1", ScopeDisplay: "Sub One"}
 	roleB := azure.Role{RoleName: "Contributor", Scope: "/subscriptions/sub-2", ScopeDisplay: "Sub Two"}
 	roleC := azure.Role{RoleName: "Reader", Scope: "/subscriptions/sub-1", ScopeDisplay: "Sub One"}
+	roleD := azure.Role{RoleName: "Contributor", Scope: "/subscriptions/e14cf978-da6b-4661-86b4-f02acd680147", ScopeDisplay: "GUID Sub"}
 
 	tests := []struct {
 		name        string
@@ -66,6 +67,14 @@ func TestAutoAdvance(t *testing.T) {
 			roleFilter:  []string{"Contributor"},
 			scopeFilter: []string{"nonexistent"},
 			wantNil:     true,
+		},
+		{
+			name:        "roleFilter matches two roles scopeFilter bare GUID emits correct role",
+			roles:       []azure.Role{roleA, roleD},
+			roleFilter:  []string{"Contributor"},
+			scopeFilter: []string{"e14cf978-da6b-4661-86b4-f02acd680147"},
+			wantNil:     false,
+			wantRole:    roleD,
 		},
 	}
 

--- a/internal/tui/activate/rolelist_test.go
+++ b/internal/tui/activate/rolelist_test.go
@@ -10,7 +10,7 @@ func TestAutoAdvance(t *testing.T) {
 	roleA := azure.Role{RoleName: "Contributor", Scope: "/subscriptions/sub-1", ScopeDisplay: "Sub One"}
 	roleB := azure.Role{RoleName: "Contributor", Scope: "/subscriptions/sub-2", ScopeDisplay: "Sub Two"}
 	roleC := azure.Role{RoleName: "Reader", Scope: "/subscriptions/sub-1", ScopeDisplay: "Sub One"}
-	roleD := azure.Role{RoleName: "Contributor", Scope: "/subscriptions/e14cf978-da6b-4661-86b4-f02acd680147", ScopeDisplay: "GUID Sub"}
+	roleD := azure.Role{RoleName: "Contributor", Scope: "/subscriptions/00000000-0000-0000-0000-000000000000", ScopeDisplay: "GUID Sub"}
 
 	tests := []struct {
 		name        string
@@ -72,7 +72,7 @@ func TestAutoAdvance(t *testing.T) {
 			name:        "roleFilter matches two roles scopeFilter bare GUID emits correct role",
 			roles:       []azure.Role{roleA, roleD},
 			roleFilter:  []string{"Contributor"},
-			scopeFilter: []string{"e14cf978-da6b-4661-86b4-f02acd680147"},
+			scopeFilter: []string{"00000000-0000-0000-0000-000000000000"},
 			wantNil:     false,
 			wantRole:    roleD,
 		},

--- a/internal/tui/activate/scopetree.go
+++ b/internal/tui/activate/scopetree.go
@@ -270,7 +270,7 @@ func (m ScopeTree) Update(msg tea.Msg) (ScopeTree, tea.Cmd) {
 		case msg.String() == "space":
 			if m.cursor < len(m.flat) {
 				n := m.flat[m.cursor]
-				if n.loadErr != nil && n != m.root {
+				if n.loadErr != nil && n != m.root && n.kind != azure.ScopeSubscription {
 					break
 				}
 				scope := n.scope

--- a/internal/tui/activate/scopetree.go
+++ b/internal/tui/activate/scopetree.go
@@ -47,14 +47,15 @@ type ScopeTree struct {
 	// subRoot is true when the tree is rooted at a subscription (not an MG).
 	// In this mode the root can be selected directly without expansion.
 	subRoot bool
-	// loadSubs fetches subscriptions under a management group ID.
-	loadSubs func(mgID string) ([]azure.Subscription, error)
+	// loadSubs fetches child management groups and subscriptions under a management group ID.
+	loadSubs func(mgID string) ([]azure.ManagementGroup, []azure.Subscription, error)
 	// loadRGs fetches resource groups under a subscription ID.
 	loadRGs func(subID string) ([]azure.ResourceGroup, error)
 }
 
 type scopeChildrenMsg struct {
 	parentScope string
+	mgs         []azure.ManagementGroup
 	subs        []azure.Subscription
 	rgs         []azure.ResourceGroup
 	err         error
@@ -65,7 +66,7 @@ func NewScopeTree(
 	theme styles.Theme,
 	keys styles.KeyMap,
 	role azure.Role,
-	loadSubs func(string) ([]azure.Subscription, error),
+	loadSubs func(string) ([]azure.ManagementGroup, []azure.Subscription, error),
 	loadRGs func(string) ([]azure.ResourceGroup, error),
 ) ScopeTree {
 	root := &scopeNode{
@@ -135,7 +136,8 @@ func (m ScopeTree) expandNode(n *scopeNode) tea.Cmd {
 		switch kind {
 		case azure.ScopeManagementGroup:
 			mgID := azure.ManagementGroupIDFromScope(scope)
-			subs, err := m.loadSubs(mgID)
+			mgs, subs, err := m.loadSubs(mgID)
+			msg.mgs = mgs
 			msg.subs = subs
 			msg.err = err
 		case azure.ScopeSubscription:
@@ -167,6 +169,15 @@ func (m ScopeTree) Update(msg tea.Msg) (ScopeTree, tea.Cmd) {
 		}
 		n.loaded = true
 		n.expanded = true
+		for _, mg := range msg.mgs {
+			n.children = append(n.children, &scopeNode{
+				id:      mg.ID,
+				display: mg.DisplayName,
+				kind:    azure.ScopeManagementGroup,
+				scope:   mg.Scope(),
+				parent:  n,
+			})
+		}
 		for _, s := range msg.subs {
 			n.children = append(n.children, &scopeNode{
 				id:      s.ID,

--- a/internal/tui/activate/scopetree.go
+++ b/internal/tui/activate/scopetree.go
@@ -34,16 +34,19 @@ type scopeNode struct {
 
 // ScopeTree is Step 2: lazy-loaded scope tree for MG- or subscription-scoped roles.
 type ScopeTree struct {
-	theme    styles.Theme
-	keys     styles.KeyMap
-	spinner  components.Spinner
-	role     azure.Role
-	root     *scopeNode
-	flat     []*scopeNode // flattened visible list
-	cursor   int
-	selected map[string]bool // set of selected scope paths
-	width    int
-	height   int
+	theme     styles.Theme
+	keys      styles.KeyMap
+	spinner   components.Spinner
+	role      azure.Role
+	root      *scopeNode
+	flat      []*scopeNode // flattened visible list
+	cursor    int
+	viewport  int             // top visible row index
+	selected  map[string]bool // set of selected scope paths
+	filter    string
+	filtering bool
+	width     int
+	height    int
 	// subRoot is true when the tree is rooted at a subscription (not an MG).
 	// In this mode the root can be selected directly without expansion.
 	subRoot bool
@@ -124,6 +127,9 @@ func (m ScopeTree) Init() tea.Cmd {
 	return m.spinner.Init()
 }
 
+// Editing reports whether the filter text field is active.
+func (m ScopeTree) Editing() bool { return m.filtering }
+
 func (m ScopeTree) expandNode(n *scopeNode) tea.Cmd {
 	if n.loaded || n.loading {
 		return nil
@@ -199,15 +205,30 @@ func (m ScopeTree) Update(msg tea.Msg) (ScopeTree, tea.Cmd) {
 		m.flatten()
 
 	case tea.KeyPressMsg:
+		if m.filtering {
+			return m.updateFilter(msg)
+		}
 		switch {
 		case key.Matches(msg, m.keys.Up), msg.String() == "k":
 			if m.cursor > 0 {
 				m.cursor--
+				m.adjustViewport()
 			}
 		case key.Matches(msg, m.keys.Down), msg.String() == "j":
 			if m.cursor < len(m.flat)-1 {
 				m.cursor++
+				m.adjustViewport()
 			}
+		case msg.String() == "/":
+			m.filtering = true
+		case msg.String() == "esc":
+			if m.filter != "" {
+				m.filter = ""
+				m.flatten()
+				m.cursor = 0
+				m.viewport = 0
+			}
+			// wizard handles Back when filter is empty
 		case msg.String() == "l", msg.String() == "right":
 			if m.cursor < len(m.flat) {
 				n := m.flat[m.cursor]
@@ -240,6 +261,7 @@ func (m ScopeTree) Update(msg tea.Msg) (ScopeTree, tea.Cmd) {
 					for i, fn := range m.flat {
 						if fn == n.parent {
 							m.cursor = i
+							m.adjustViewport()
 							break
 						}
 					}
@@ -267,7 +289,7 @@ func (m ScopeTree) Update(msg tea.Msg) (ScopeTree, tea.Cmd) {
 				role := m.role
 				return m, func() tea.Msg { return ScopeTreeDoneMsg{Role: role, Scopes: scopes} }
 			}
-		case key.Matches(msg, m.keys.Back), msg.String() == "esc":
+		case key.Matches(msg, m.keys.Back):
 			// wizard handles Back
 		}
 
@@ -280,10 +302,99 @@ func (m ScopeTree) Update(msg tea.Msg) (ScopeTree, tea.Cmd) {
 	return m, nil
 }
 
-// flatten rebuilds the visible flat list from the tree.
+func (m *ScopeTree) updateFilter(msg tea.KeyPressMsg) (ScopeTree, tea.Cmd) {
+	switch msg.String() {
+	case "enter":
+		m.filtering = false
+	case "esc":
+		m.filter = ""
+		m.filtering = false
+		m.flatten()
+		m.cursor = 0
+		m.viewport = 0
+	case "backspace":
+		if len(m.filter) > 0 {
+			m.filter = m.filter[:len(m.filter)-1]
+			m.flatten()
+			m.cursor = 0
+			m.viewport = 0
+		}
+	case "space":
+		m.filter += " "
+		m.flatten()
+		m.cursor = 0
+		m.viewport = 0
+	default:
+		if r := msg.String(); len(r) == 1 {
+			m.filter += r
+			m.flatten()
+			m.cursor = 0
+			m.viewport = 0
+		}
+	}
+	return *m, nil
+}
+
+// flatten rebuilds the visible flat list from the tree, applying filter if set.
 func (m *ScopeTree) flatten() {
 	m.flat = m.flat[:0]
-	m.flattenNode(m.root)
+	if m.filter == "" {
+		m.flattenNode(m.root)
+		return
+	}
+	lower := strings.ToLower(m.filter)
+	m.flattenFiltered(m.root, lower)
+}
+
+// flattenFiltered includes a node if it or any descendant matches the filter.
+// Ancestor nodes of matching nodes are always included to preserve tree structure.
+func (m *ScopeTree) flattenFiltered(n *scopeNode, lower string) bool {
+	selfMatch := strings.Contains(strings.ToLower(n.display), lower) ||
+		strings.Contains(strings.ToLower(n.scope), lower)
+
+	childMatch := false
+	var matchingChildren []*scopeNode
+	for _, c := range n.children {
+		if m.flattenFilteredCollect(c, lower) {
+			childMatch = true
+			matchingChildren = append(matchingChildren, c)
+		}
+	}
+
+	if !selfMatch && !childMatch {
+		return false
+	}
+
+	m.flat = append(m.flat, n)
+	for _, c := range matchingChildren {
+		m.flattenFilteredEmit(c, lower)
+	}
+	return true
+}
+
+// flattenFilteredCollect returns true if n or any descendant matches.
+func (m *ScopeTree) flattenFilteredCollect(n *scopeNode, lower string) bool {
+	if strings.Contains(strings.ToLower(n.display), lower) ||
+		strings.Contains(strings.ToLower(n.scope), lower) {
+		return true
+	}
+	for _, c := range n.children {
+		if m.flattenFilteredCollect(c, lower) {
+			return true
+		}
+	}
+	return false
+}
+
+// flattenFilteredEmit appends n and its matching descendants to flat.
+func (m *ScopeTree) flattenFilteredEmit(n *scopeNode, lower string) {
+	if !m.flattenFilteredCollect(n, lower) {
+		return
+	}
+	m.flat = append(m.flat, n)
+	for _, c := range n.children {
+		m.flattenFilteredEmit(c, lower)
+	}
 }
 
 func (m *ScopeTree) flattenNode(n *scopeNode) {
@@ -311,13 +422,39 @@ func findInTree(n *scopeNode, scope string) *scopeNode {
 	return nil
 }
 
+// adjustViewport keeps cursor within the visible window.
+func (m *ScopeTree) adjustViewport() {
+	visible := max(1, m.height-6)
+	if m.cursor < m.viewport {
+		m.viewport = m.cursor
+	} else if m.cursor >= m.viewport+visible {
+		m.viewport = m.cursor - visible + 1
+	}
+}
+
 // View renders the scope tree step.
 func (m ScopeTree) View() string {
 	var sb strings.Builder
 
-	sb.WriteString(m.theme.Title.Render(fmt.Sprintf("Choose scope for %s:", m.role.RoleName)) + "\n\n")
+	sb.WriteString(m.theme.Title.Render(fmt.Sprintf("Choose scope for %s:", m.role.RoleName)) + "\n")
 
-	for i, n := range m.flat {
+	if m.filtering {
+		sb.WriteString(m.theme.Subtle.Render("Filter: ") + m.filter + "█\n")
+	} else if m.filter != "" {
+		sb.WriteString(m.theme.Subtle.Render("Filter: "+m.filter+"  (esc clear)") + "\n")
+	} else {
+		sb.WriteString("\n")
+	}
+
+	visibleRows := max(1, m.height-6)
+	start := m.viewport
+	end := start + visibleRows
+	if end > len(m.flat) {
+		end = len(m.flat)
+	}
+
+	for i := start; i < end; i++ {
+		n := m.flat[i]
 		depth := nodeDepth(n)
 		indent := strings.Repeat("  ", depth)
 
@@ -361,7 +498,7 @@ func (m ScopeTree) View() string {
 
 	hints := []key.Binding{m.keys.Up, m.keys.Down, m.keys.Enter, m.keys.Back}
 	sb.WriteString(components.RenderStatusBar(m.theme.HelpKey, m.theme.HelpDesc, m.theme.Subtle, hints,
-		"h/l collapse/expand  space toggle  → confirm"))
+		"h/l collapse/expand  space toggle  / filter  → confirm"))
 
 	return sb.String()
 }

--- a/internal/tui/activate/scopetree.go
+++ b/internal/tui/activate/scopetree.go
@@ -228,18 +228,15 @@ func (m ScopeTree) Update(msg tea.Msg) (ScopeTree, tea.Cmd) {
 				m.cursor = 0
 				m.viewport = 0
 			}
-			// wizard handles Back when filter is empty
 		case msg.String() == "l", msg.String() == "right":
 			if m.cursor < len(m.flat) {
 				n := m.flat[m.cursor]
 				if n.kind == azure.ScopeResourceGroup || n.expanded {
 					break
 				}
-				// MG nodes and subscription nodes (when sub is root) can be expanded.
-				if n.kind == azure.ScopeManagementGroup || (n.kind == azure.ScopeSubscription && n != m.root) || m.subRoot {
-					if n.loadErr != nil {
-						// Clear the previous error so expandNode will retry.
-						n.loadErr = nil
+			if n.kind == azure.ScopeManagementGroup || (n.kind == azure.ScopeSubscription && n != m.root) || m.subRoot {
+				if n.loadErr != nil {
+					n.loadErr = nil
 					}
 					if n.loaded {
 						n.expanded = true
@@ -290,7 +287,6 @@ func (m ScopeTree) Update(msg tea.Msg) (ScopeTree, tea.Cmd) {
 				return m, func() tea.Msg { return ScopeTreeDoneMsg{Role: role, Scopes: scopes} }
 			}
 		case key.Matches(msg, m.keys.Back):
-			// wizard handles Back
 		}
 
 	default:

--- a/internal/tui/activate/scopetree.go
+++ b/internal/tui/activate/scopetree.go
@@ -424,12 +424,25 @@ func findInTree(n *scopeNode, scope string) *scopeNode {
 
 // adjustViewport keeps cursor within the visible window.
 func (m *ScopeTree) adjustViewport() {
-	visible := max(1, m.height-6)
+	visible := m.visibleRows()
 	if m.cursor < m.viewport {
 		m.viewport = m.cursor
 	} else if m.cursor >= m.viewport+visible {
 		m.viewport = m.cursor - visible + 1
 	}
+}
+
+// visibleRows returns the number of rows the viewport can display.
+// When height is unknown (0), all flat rows are visible so nothing is clipped.
+func (m ScopeTree) visibleRows() int {
+	if m.height == 0 {
+		return max(1, len(m.flat))
+	}
+	v := m.height - 6
+	if v < 1 {
+		return 1
+	}
+	return v
 }
 
 // View renders the scope tree step.
@@ -446,7 +459,7 @@ func (m ScopeTree) View() string {
 		sb.WriteString("\n")
 	}
 
-	visibleRows := max(1, m.height-6)
+	visibleRows := m.visibleRows()
 	start := m.viewport
 	end := start + visibleRows
 	if end > len(m.flat) {

--- a/internal/tui/activate/scopetree.go
+++ b/internal/tui/activate/scopetree.go
@@ -117,16 +117,10 @@ func NewScopeTreeForSub(
 	return st
 }
 
-// Init starts the spinner and, for MG-rooted trees, triggers root expansion.
+// Init starts the spinner. Children are loaded lazily when the user presses
+// l/right to expand; the MG root itself is always selectable without expansion.
 func (m ScopeTree) Init() tea.Cmd {
-	if m.subRoot {
-		// Subscription-rooted: don't auto-expand; user selects sub or drills to RGs.
-		return m.spinner.Init()
-	}
-	return tea.Batch(
-		m.spinner.Init(),
-		m.expandNode(m.root),
-	)
+	return m.spinner.Init()
 }
 
 func (m ScopeTree) expandNode(n *scopeNode) tea.Cmd {
@@ -243,7 +237,7 @@ func (m ScopeTree) Update(msg tea.Msg) (ScopeTree, tea.Cmd) {
 		case msg.String() == "space":
 			if m.cursor < len(m.flat) {
 				n := m.flat[m.cursor]
-				if n.loadErr != nil {
+				if n.loadErr != nil && n != m.root {
 					break
 				}
 				scope := n.scope

--- a/internal/tui/activate/scopetree_test.go
+++ b/internal/tui/activate/scopetree_test.go
@@ -36,6 +36,36 @@ func TestScopeTreeInitDoesNotAutoExpand(t *testing.T) {
 	}
 }
 
+func TestScopeTreeChildrenFlattenedWithCorrectDepth(t *testing.T) {
+	st := newTestScopeTree(func(mgID string) ([]azure.ManagementGroup, []azure.Subscription, error) {
+		return nil, nil, nil
+	})
+
+	msg := scopeChildrenMsg{
+		parentScope: st.root.scope,
+		mgs: []azure.ManagementGroup{
+			{ID: "child-mg", DisplayName: "Child MG"},
+		},
+		subs: []azure.Subscription{
+			{ID: "00000000-0000-0000-0000-000000000001", DisplayName: "My Sub"},
+		},
+	}
+	st, _ = st.Update(msg)
+
+	if len(st.flat) != 3 {
+		t.Fatalf("expected 3 flat nodes (root + 1 MG + 1 sub), got %d", len(st.flat))
+	}
+	if nodeDepth(st.flat[0]) != 0 {
+		t.Errorf("flat[0] (root) depth: want 0, got %d", nodeDepth(st.flat[0]))
+	}
+	if nodeDepth(st.flat[1]) != 1 {
+		t.Errorf("flat[1] depth: want 1, got %d", nodeDepth(st.flat[1]))
+	}
+	if nodeDepth(st.flat[2]) != 1 {
+		t.Errorf("flat[2] depth: want 1, got %d", nodeDepth(st.flat[2]))
+	}
+}
+
 func TestScopeTreeRootSelectableAfterLoadErr(t *testing.T) {
 	loadErr := errors.New("HTTP 403 AuthorizationFailed")
 	st := newTestScopeTree(func(mgID string) ([]azure.ManagementGroup, []azure.Subscription, error) {

--- a/internal/tui/activate/scopetree_test.go
+++ b/internal/tui/activate/scopetree_test.go
@@ -98,6 +98,27 @@ func TestScopeTreeRootSelectableAfterLoadErr(t *testing.T) {
 	}
 }
 
+func TestScopeTreeSubscriptionSelectableAfterRGLoadErr(t *testing.T) {
+	st := newTestScopeTree(func(mgID string) ([]azure.ManagementGroup, []azure.Subscription, error) {
+		return nil, nil, nil
+	})
+	sub := azure.Subscription{ID: "00000000-0000-0000-0000-000000000001", DisplayName: "My Sub"}
+	st, _ = st.Update(scopeChildrenMsg{
+		parentScope: st.root.scope,
+		subs:        []azure.Subscription{sub},
+	})
+	st, _ = st.Update(scopeChildrenMsg{
+		parentScope: sub.Scope(),
+		err:         errors.New("HTTP 403 AuthorizationFailed"),
+	})
+
+	st.cursor = 1
+	st, _ = st.Update(tea.KeyPressMsg{Code: tea.KeySpace, Text: " "})
+	if !st.selected[sub.Scope()] {
+		t.Error("subscription scope not selectable after RG load error")
+	}
+}
+
 func TestStartNextScopeTreePropagatesDimensions(t *testing.T) {
 	theme := styles.NewTheme(true)
 	keys := styles.DefaultKeyMap

--- a/internal/tui/activate/scopetree_test.go
+++ b/internal/tui/activate/scopetree_test.go
@@ -1,0 +1,68 @@
+package activate
+
+import (
+	"errors"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/jeircul/pim/internal/azure"
+	"github.com/jeircul/pim/internal/tui/styles"
+)
+
+func newTestScopeTree(loadSubs func(string) ([]azure.Subscription, error)) ScopeTree {
+	role := azure.Role{
+		RoleName:     "Contributor",
+		Scope:        "/providers/Microsoft.Management/managementGroups/Omnia",
+		ScopeDisplay: "Omnia",
+	}
+	theme := styles.NewTheme(true)
+	keys := styles.DefaultKeyMap
+	return NewScopeTree(theme, keys, role, loadSubs, nil)
+}
+
+func TestScopeTreeInitDoesNotAutoExpand(t *testing.T) {
+	called := false
+	st := newTestScopeTree(func(mgID string) ([]azure.Subscription, error) {
+		called = true
+		return nil, nil
+	})
+
+	cmd := st.Init()
+	if cmd == nil {
+		t.Fatal("Init() returned nil; expected spinner cmd")
+	}
+	if called {
+		t.Error("Init() triggered loadSubs; MG root should not auto-expand")
+	}
+}
+
+func TestScopeTreeRootSelectableAfterLoadErr(t *testing.T) {
+	loadErr := errors.New("HTTP 403 AuthorizationFailed")
+	st := newTestScopeTree(func(mgID string) ([]azure.Subscription, error) {
+		return nil, loadErr
+	})
+
+	msg := scopeChildrenMsg{
+		parentScope: st.root.scope,
+		err:         loadErr,
+	}
+	st, _ = st.Update(msg)
+
+	if st.root.loadErr == nil {
+		t.Fatal("expected root.loadErr to be set after failed child load")
+	}
+
+	if len(st.flat) == 0 {
+		t.Fatal("flat list is empty")
+	}
+	st.cursor = 0
+	n := st.flat[0]
+	if n != st.root {
+		t.Fatal("flat[0] is not root")
+	}
+
+	st2, _ := st.Update(tea.KeyPressMsg{Code: tea.KeySpace, Text: " "})
+	if !st2.selected[st.root.scope] {
+		t.Error("root scope not selectable after loadErr")
+	}
+}

--- a/internal/tui/activate/scopetree_test.go
+++ b/internal/tui/activate/scopetree_test.go
@@ -2,6 +2,7 @@ package activate
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -129,4 +130,104 @@ func TestStartNextScopeTreePropagatesDimensions(t *testing.T) {
 	if w.scopeTree.height != 50 {
 		t.Errorf("scopeTree.height: want 50, got %d", w.scopeTree.height)
 	}
+}
+
+func TestWizardWithSizePropagates(t *testing.T) {
+	theme := styles.NewTheme(true)
+	keys := styles.DefaultKeyMap
+	deps := Deps{
+		LoadRoles:  func() ([]azure.Role, error) { return nil, nil },
+		LoadActive: func() ([]azure.ActiveAssignment, error) { return nil, nil },
+	}
+	w := New(theme, keys, deps).WithSize(120, 40)
+
+	if w.width != 120 || w.height != 40 {
+		t.Errorf("wizard dimensions: want 120x40, got %dx%d", w.width, w.height)
+	}
+	if w.roleList.width != 120 || w.roleList.height != 40 {
+		t.Errorf("roleList dimensions: want 120x40, got %dx%d", w.roleList.width, w.roleList.height)
+	}
+	if w.scopeTree.width != 120 || w.scopeTree.height != 40 {
+		t.Errorf("scopeTree dimensions: want 120x40, got %dx%d", w.scopeTree.width, w.scopeTree.height)
+	}
+	if w.options.width != 120 || w.options.height != 40 {
+		t.Errorf("options dimensions: want 120x40, got %dx%d", w.options.width, w.options.height)
+	}
+	if w.confirm.width != 120 || w.confirm.height != 40 {
+		t.Errorf("confirm dimensions: want 120x40, got %dx%d", w.confirm.width, w.confirm.height)
+	}
+}
+
+func TestScopeTreeZeroHeightRendersAllRows(t *testing.T) {
+	st := newTestScopeTree(func(mgID string) ([]azure.ManagementGroup, []azure.Subscription, error) {
+		return nil, nil, nil
+	})
+
+	msg := scopeChildrenMsg{
+		parentScope: st.root.scope,
+		mgs: []azure.ManagementGroup{
+			{ID: "child-mg-1", DisplayName: "Child MG 1"},
+			{ID: "child-mg-2", DisplayName: "Child MG 2"},
+		},
+	}
+	st, _ = st.Update(msg)
+
+	if st.height != 0 {
+		t.Fatalf("precondition: height should be 0, got %d", st.height)
+	}
+	if len(st.flat) != 3 {
+		t.Fatalf("expected 3 flat nodes, got %d", len(st.flat))
+	}
+
+	visible := st.visibleRows()
+	if visible < len(st.flat) {
+		t.Errorf("visibleRows() = %d with height=0, want >= %d (all rows)", visible, len(st.flat))
+	}
+	view := st.View()
+	if !strings.Contains(view, "Child MG 1") || !strings.Contains(view, "Child MG 2") {
+		t.Errorf("View() with height=0 did not render expanded children:\n%s", view)
+	}
+}
+
+func TestScopeTreeFilterEscDoesNotTriggerWizardBack(t *testing.T) {
+	theme := styles.NewTheme(true)
+	keys := styles.DefaultKeyMap
+	role := azure.Role{
+		RoleName:     "Contributor",
+		Scope:        "/providers/Microsoft.Management/managementGroups/Omnia",
+		ScopeDisplay: "Omnia",
+	}
+	w := Wizard{
+		theme:  theme,
+		keys:   keys,
+		width:  120,
+		height: 40,
+		step:   stepScopeTree,
+		deps: Deps{
+			LoadSubs: func(mgID string) ([]azure.ManagementGroup, []azure.Subscription, error) {
+				return nil, nil, nil
+			},
+			LoadRGs: func(subID string) ([]azure.ResourceGroup, error) {
+				return nil, nil
+			},
+		},
+	}
+	w.scopeTree = NewScopeTree(theme, keys, role, w.deps.LoadSubs, w.deps.LoadRGs)
+	w.scopeTree.width = 120
+	w.scopeTree.height = 40
+
+	w, _ = w.Update(tea.KeyPressMsg{Text: "/"})
+	if !w.scopeTree.filtering {
+		t.Fatal("expected filtering=true after '/'")
+	}
+
+	var cmd tea.Cmd
+	w, cmd = w.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if w.scopeTree.filtering {
+		t.Error("expected filtering=false after esc")
+	}
+	if w.step != stepScopeTree {
+		t.Errorf("expected step=stepScopeTree after esc in filter, got %d", w.step)
+	}
+	_ = cmd
 }

--- a/internal/tui/activate/scopetree_test.go
+++ b/internal/tui/activate/scopetree_test.go
@@ -96,3 +96,37 @@ func TestScopeTreeRootSelectableAfterLoadErr(t *testing.T) {
 		t.Error("root scope not selectable after loadErr")
 	}
 }
+
+func TestStartNextScopeTreePropagatesDimensions(t *testing.T) {
+	theme := styles.NewTheme(true)
+	keys := styles.DefaultKeyMap
+	role := azure.Role{
+		RoleName:     "Contributor",
+		Scope:        "/providers/Microsoft.Management/managementGroups/Omnia",
+		ScopeDisplay: "Omnia",
+	}
+	w := Wizard{
+		theme:  theme,
+		keys:   keys,
+		width:  200,
+		height: 50,
+		deps: Deps{
+			LoadSubs: func(mgID string) ([]azure.ManagementGroup, []azure.Subscription, error) {
+				return nil, nil, nil
+			},
+			LoadRGs: func(subID string) ([]azure.ResourceGroup, error) {
+				return nil, nil
+			},
+		},
+	}
+	w.scopeQueue = []azure.Role{role}
+
+	w, _ = w.startNextScopeTree()
+
+	if w.scopeTree.width != 200 {
+		t.Errorf("scopeTree.width: want 200, got %d", w.scopeTree.width)
+	}
+	if w.scopeTree.height != 50 {
+		t.Errorf("scopeTree.height: want 50, got %d", w.scopeTree.height)
+	}
+}

--- a/internal/tui/activate/scopetree_test.go
+++ b/internal/tui/activate/scopetree_test.go
@@ -13,8 +13,8 @@ import (
 func newTestScopeTree(loadSubs func(string) ([]azure.ManagementGroup, []azure.Subscription, error)) ScopeTree {
 	role := azure.Role{
 		RoleName:     "Contributor",
-		Scope:        "/providers/Microsoft.Management/managementGroups/Omnia",
-		ScopeDisplay: "Omnia",
+		Scope:        "/providers/Microsoft.Management/managementGroups/Contoso",
+		ScopeDisplay: "Contoso",
 	}
 	theme := styles.NewTheme(true)
 	keys := styles.DefaultKeyMap
@@ -124,8 +124,8 @@ func TestStartNextScopeTreePropagatesDimensions(t *testing.T) {
 	keys := styles.DefaultKeyMap
 	role := azure.Role{
 		RoleName:     "Contributor",
-		Scope:        "/providers/Microsoft.Management/managementGroups/Omnia",
-		ScopeDisplay: "Omnia",
+		Scope:        "/providers/Microsoft.Management/managementGroups/Contoso",
+		ScopeDisplay: "Contoso",
 	}
 	w := Wizard{
 		theme:  theme,
@@ -215,8 +215,8 @@ func TestScopeTreeFilterEscDoesNotTriggerWizardBack(t *testing.T) {
 	keys := styles.DefaultKeyMap
 	role := azure.Role{
 		RoleName:     "Contributor",
-		Scope:        "/providers/Microsoft.Management/managementGroups/Omnia",
-		ScopeDisplay: "Omnia",
+		Scope:        "/providers/Microsoft.Management/managementGroups/Contoso",
+		ScopeDisplay: "Contoso",
 	}
 	w := Wizard{
 		theme:  theme,

--- a/internal/tui/activate/scopetree_test.go
+++ b/internal/tui/activate/scopetree_test.go
@@ -13,8 +13,8 @@ import (
 func newTestScopeTree(loadSubs func(string) ([]azure.ManagementGroup, []azure.Subscription, error)) ScopeTree {
 	role := azure.Role{
 		RoleName:     "Contributor",
-		Scope:        "/providers/Microsoft.Management/managementGroups/Contoso",
-		ScopeDisplay: "Contoso",
+		Scope:        "/providers/Microsoft.Management/managementGroups/example-mg",
+		ScopeDisplay: "example-mg",
 	}
 	theme := styles.NewTheme(true)
 	keys := styles.DefaultKeyMap
@@ -48,7 +48,7 @@ func TestScopeTreeChildrenFlattenedWithCorrectDepth(t *testing.T) {
 			{ID: "child-mg", DisplayName: "Child MG"},
 		},
 		subs: []azure.Subscription{
-			{ID: "00000000-0000-0000-0000-000000000001", DisplayName: "My Sub"},
+			{ID: "00000000-0000-0000-0000-000000000000", DisplayName: "My Sub"},
 		},
 	}
 	st, _ = st.Update(msg)
@@ -102,7 +102,7 @@ func TestScopeTreeSubscriptionSelectableAfterRGLoadErr(t *testing.T) {
 	st := newTestScopeTree(func(mgID string) ([]azure.ManagementGroup, []azure.Subscription, error) {
 		return nil, nil, nil
 	})
-	sub := azure.Subscription{ID: "00000000-0000-0000-0000-000000000001", DisplayName: "My Sub"}
+	sub := azure.Subscription{ID: "00000000-0000-0000-0000-000000000000", DisplayName: "My Sub"}
 	st, _ = st.Update(scopeChildrenMsg{
 		parentScope: st.root.scope,
 		subs:        []azure.Subscription{sub},
@@ -124,8 +124,8 @@ func TestStartNextScopeTreePropagatesDimensions(t *testing.T) {
 	keys := styles.DefaultKeyMap
 	role := azure.Role{
 		RoleName:     "Contributor",
-		Scope:        "/providers/Microsoft.Management/managementGroups/Contoso",
-		ScopeDisplay: "Contoso",
+		Scope:        "/providers/Microsoft.Management/managementGroups/example-mg",
+		ScopeDisplay: "example-mg",
 	}
 	w := Wizard{
 		theme:  theme,
@@ -215,8 +215,8 @@ func TestScopeTreeFilterEscDoesNotTriggerWizardBack(t *testing.T) {
 	keys := styles.DefaultKeyMap
 	role := azure.Role{
 		RoleName:     "Contributor",
-		Scope:        "/providers/Microsoft.Management/managementGroups/Contoso",
-		ScopeDisplay: "Contoso",
+		Scope:        "/providers/Microsoft.Management/managementGroups/example-mg",
+		ScopeDisplay: "example-mg",
 	}
 	w := Wizard{
 		theme:  theme,

--- a/internal/tui/activate/scopetree_test.go
+++ b/internal/tui/activate/scopetree_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jeircul/pim/internal/tui/styles"
 )
 
-func newTestScopeTree(loadSubs func(string) ([]azure.Subscription, error)) ScopeTree {
+func newTestScopeTree(loadSubs func(string) ([]azure.ManagementGroup, []azure.Subscription, error)) ScopeTree {
 	role := azure.Role{
 		RoleName:     "Contributor",
 		Scope:        "/providers/Microsoft.Management/managementGroups/Omnia",
@@ -22,9 +22,9 @@ func newTestScopeTree(loadSubs func(string) ([]azure.Subscription, error)) Scope
 
 func TestScopeTreeInitDoesNotAutoExpand(t *testing.T) {
 	called := false
-	st := newTestScopeTree(func(mgID string) ([]azure.Subscription, error) {
+	st := newTestScopeTree(func(mgID string) ([]azure.ManagementGroup, []azure.Subscription, error) {
 		called = true
-		return nil, nil
+		return nil, nil, nil
 	})
 
 	cmd := st.Init()
@@ -38,8 +38,8 @@ func TestScopeTreeInitDoesNotAutoExpand(t *testing.T) {
 
 func TestScopeTreeRootSelectableAfterLoadErr(t *testing.T) {
 	loadErr := errors.New("HTTP 403 AuthorizationFailed")
-	st := newTestScopeTree(func(mgID string) ([]azure.Subscription, error) {
-		return nil, loadErr
+	st := newTestScopeTree(func(mgID string) ([]azure.ManagementGroup, []azure.Subscription, error) {
+		return nil, nil, loadErr
 	})
 
 	msg := scopeChildrenMsg{

--- a/internal/tui/activate/wizard.go
+++ b/internal/tui/activate/wizard.go
@@ -76,6 +76,21 @@ func New(theme styles.Theme, keys styles.KeyMap, deps Deps) Wizard {
 	return w
 }
 
+// WithSize returns a copy of w with width and height propagated to all step models.
+func (w Wizard) WithSize(width, height int) Wizard {
+	w.width = width
+	w.height = height
+	w.roleList.width = width
+	w.roleList.height = height
+	w.scopeTree.width = width
+	w.scopeTree.height = height
+	w.options.width = width
+	w.options.height = height
+	w.confirm.width = width
+	w.confirm.height = height
+	return w
+}
+
 // Init starts the first step (or fast-forwards if flags allow).
 func (w Wizard) Init() tea.Cmd {
 	return w.roleList.Init()
@@ -86,6 +101,8 @@ func (w Wizard) Editing() bool {
 	switch w.step {
 	case stepRoleList:
 		return w.roleList.Editing()
+	case stepScopeTree:
+		return w.scopeTree.Editing()
 	case stepOptions:
 		return w.options.Editing()
 	}
@@ -96,17 +113,7 @@ func (w Wizard) Editing() bool {
 func (w Wizard) Update(msg tea.Msg) (Wizard, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		w.width = msg.Width
-		w.height = msg.Height
-		// propagate to active step
-		w.roleList.width = msg.Width
-		w.roleList.height = msg.Height
-		w.scopeTree.width = msg.Width
-		w.scopeTree.height = msg.Height
-		w.options.width = msg.Width
-		w.options.height = msg.Height
-		w.confirm.width = msg.Width
-		w.confirm.height = msg.Height
+		w = w.WithSize(msg.Width, msg.Height)
 
 	case RoleListDoneMsg:
 		w.selectedRoles = msg.Selected
@@ -150,7 +157,9 @@ func (w Wizard) Update(msg tea.Msg) (Wizard, tea.Cmd) {
 		w.roleList, cmd = w.roleList.Update(msg)
 		consumed = roleListConsumed(prev, w.roleList, msg)
 	case stepScopeTree:
+		prev := w.scopeTree
 		w.scopeTree, cmd = w.scopeTree.Update(msg)
+		consumed = scopeTreeConsumed(prev, w.scopeTree, msg)
 	case stepOptions:
 		w.options, cmd = w.options.Update(msg)
 	case stepConfirm:
@@ -230,6 +239,20 @@ func roleListConsumed(prev, next RoleList, msg tea.Msg) bool {
 		return s != "enter" && s != "esc"
 	}
 	return false
+}
+
+// scopeTreeConsumed reports whether the scope tree consumed the message.
+// It returns true when the tree was filtering (all keys including enter/esc that exit
+// filter mode) or when "/" opened filter mode.
+func scopeTreeConsumed(prev, next ScopeTree, msg tea.Msg) bool {
+	kp, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return false
+	}
+	if prev.filtering {
+		return true
+	}
+	return kp.String() == "/" && next.filtering
 }
 
 // View renders the current step with a wizard header.

--- a/internal/tui/activate/wizard.go
+++ b/internal/tui/activate/wizard.go
@@ -316,6 +316,8 @@ func (w Wizard) startNextScopeTree() (Wizard, tea.Cmd) {
 	} else {
 		w.scopeTree = NewScopeTree(w.theme, w.keys, role, w.deps.LoadSubs, w.deps.LoadRGs)
 	}
+	w.scopeTree.width = w.width
+	w.scopeTree.height = w.height
 	w.step = stepScopeTree
 	w.scopeVisited = true
 	return w, w.scopeTree.Init()

--- a/internal/tui/activate/wizard.go
+++ b/internal/tui/activate/wizard.go
@@ -39,7 +39,7 @@ type Deps struct {
 	Store       *state.Store
 	LoadRoles   func() ([]azure.Role, error)
 	LoadActive  func() ([]azure.ActiveAssignment, error)
-	LoadSubs    func(mgID string) ([]azure.Subscription, error)
+	LoadSubs    func(mgID string) ([]azure.ManagementGroup, []azure.Subscription, error)
 	LoadRGs     func(subID string) ([]azure.ResourceGroup, error)
 	Activate    func(role azure.Role, principalID, justification string, minutes int, targetScope string) error
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -347,7 +347,7 @@ func (m *AppModel) startWizard(fav *state.Favorite, autoSubmit bool) tea.Cmd {
 		m.favoritePending = true
 	}
 
-	m.wizardModel = activate.New(m.theme, m.keys, deps)
+	m.wizardModel = activate.New(m.theme, m.keys, deps).WithSize(m.width, m.height)
 	m.screen = ScreenActivate
 	return m.wizardModel.Init()
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -320,10 +320,10 @@ func (m *AppModel) startWizard(fav *state.Favorite, autoSubmit bool) tea.Cmd {
 			defer callCancel()
 			return client.GetActiveAssignments(callCtx)
 		},
-		LoadSubs: func(mgID string) ([]azure.Subscription, error) {
+		LoadSubs: func(mgID string) ([]azure.ManagementGroup, []azure.Subscription, error) {
 			callCtx, callCancel := context.WithTimeout(ctx, 30*time.Second)
 			defer callCancel()
-			return client.ListManagementGroupSubscriptions(callCtx, mgID)
+			return client.ListManagementGroupChildren(callCtx, mgID)
 		},
 		LoadRGs: func(subID string) ([]azure.ResourceGroup, error) {
 			callCtx, callCancel := context.WithTimeout(ctx, 30*time.Second)

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,6 +1,7 @@
 param(
     [string]$Version = "latest",
-    [string]$InstallDir = "$env:LOCALAPPDATA\Programs\pim"
+    [string]$InstallDir = "$env:LOCALAPPDATA\Programs\pim",
+    [switch]$Dev
 )
 
 $ErrorActionPreference = "Stop"
@@ -19,7 +20,16 @@ switch ($architecture) {
 }
 
 $asset = "{0}_{1}_{2}.zip" -f $binary, $os, $arch
-if ($Version -eq "latest") {
+if ($Dev) {
+    $releases = Invoke-WebRequest -Uri "https://api.github.com/repos/$repo/releases" -UseBasicParsing | ConvertFrom-Json
+    $pre = $releases | Where-Object { $_.prerelease -eq $true } | Select-Object -First 1
+    if (-not $pre) {
+        Write-Error "No pre-release found for $repo"
+        exit 1
+    }
+    $Version = $pre.tag_name
+    $downloadUrl = "https://github.com/$repo/releases/download/$Version/$asset"
+} elseif ($Version -eq "latest") {
     $downloadUrl = "https://github.com/$repo/releases/latest/download/$asset"
 } else {
     if ($Version -notmatch '^v') {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -21,8 +21,16 @@ switch ($architecture) {
 
 $asset = "{0}_{1}_{2}.zip" -f $binary, $os, $arch
 if ($Dev) {
-    $releases = Invoke-WebRequest -Uri "https://api.github.com/repos/$repo/releases" -UseBasicParsing | ConvertFrom-Json
-    $pre = $releases | Where-Object { $_.prerelease -eq $true } | Select-Object -First 1
+    $releases = Invoke-WebRequest -Uri "https://api.github.com/repos/$repo/releases?per_page=100" -UseBasicParsing | ConvertFrom-Json
+    $pre = $releases |
+        Where-Object { $_.prerelease -eq $true } |
+        Sort-Object {
+            $t = $_.tag_name
+            $base = [System.Version]($t -replace '^v' -replace '-.*')
+            $n = if ($t -match '-dev\.(\d+)-') { [int]$Matches[1] } else { 0 }
+            [tuple]::Create($base, $n)
+        } -Descending |
+        Select-Object -First 1
     if (-not $pre) {
         Write-Error "No pre-release found for $repo"
         exit 1


### PR DESCRIPTION
Fixes two v0.5.0 scope issues:

- MG activation: scope tree no longer auto-loads child subscriptions on entry, and the MG root remains selectable even if child subscription listing returns 403.
- Headless scope filters: bare subscription GUIDs now expand to `/subscriptions/<guid>` for ARM matching; bare MG IDs expand to management group ARM paths while preserving display-name/raw-scope substring fallback.

Validation:
- `task fmt`
- `go test ./internal/azure ./internal/headless ./internal/tui/activate`
- `task test`
- `task build`