### PR TITLE
chore: apply gofmt and harden release preconditions

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -99,6 +99,8 @@ tasks:
     preconditions:
       - sh: "task fmt"
         msg: "fmt failed"
+      - sh: "[ -z \"$(git status --porcelain)\" ]"
+        msg: "Working tree is dirty after fmt — commit formatting/generated changes before releasing"
       - sh: "task test"
         msg: "tests failed"
 
@@ -137,6 +139,8 @@ tasks:
     preconditions:
       - sh: "task fmt"
         msg: "fmt failed"
+      - sh: "[ -z \"$(git status --porcelain)\" ]"
+        msg: "Working tree is dirty after fmt — commit formatting/generated changes before releasing"
       - sh: "task test"
         msg: "tests failed"
 

--- a/internal/tui/activate/scopetree.go
+++ b/internal/tui/activate/scopetree.go
@@ -234,9 +234,9 @@ func (m ScopeTree) Update(msg tea.Msg) (ScopeTree, tea.Cmd) {
 				if n.kind == azure.ScopeResourceGroup || n.expanded {
 					break
 				}
-			if n.kind == azure.ScopeManagementGroup || (n.kind == azure.ScopeSubscription && n != m.root) || m.subRoot {
-				if n.loadErr != nil {
-					n.loadErr = nil
+				if n.kind == azure.ScopeManagementGroup || (n.kind == azure.ScopeSubscription && n != m.root) || m.subRoot {
+					if n.loadErr != nil {
+						n.loadErr = nil
 					}
 					if n.loaded {
 						n.expanded = true


### PR DESCRIPTION
Fixes the gofmt-only diff that was produced locally by the v0.6.0 release precondition after the tag was created, and prevents this class of mistake from recurring.\n\nChanges:\n- Apply gofmt to internal/tui/activate/scopetree.go\n- Make release:dev and release:stable fail if task fmt leaves the working tree dirty\n\nValidation:\n- task test\n- task build