### PR TITLE
chore: update AI config docs with v0.7.0 session learnings

### DIFF
--- a/.agents/skills/golang/SKILL.md
+++ b/.agents/skills/golang/SKILL.md
@@ -105,6 +105,11 @@ client.DeactivateRole(assignment ActiveAssignment, principalID string) (*Schedul
 // 1. ARM exact match: ScopeIsChildOf(expanded, role.Scope) — fastest, deterministic
 // 2. MG-trust (TUI only): subscription filter vs MG-scoped role — first match, Azure rejects wrong scope
 // Use pim search --output toml to get scope = /subscriptions/<guid> for any role.
+// pim search pipeline:
+// buildSearchHits() returns ([]SearchHit, subRoleMap, error)
+// subRoleMap[strings.ToLower(subID)][strings.ToLower(roleName)] = azure.Role
+// tomlFromHits() consumes both — direct O(1) lookup, no MG ID reconstruction.
+// See references/mg-search.md for full design contract.
 ```
 
 ## Testing
@@ -147,3 +152,4 @@ See `references/anti-patterns.md` for a full list with corrections.
 
 **TL;DR**: no Cobra/urfave, no `pkg/`, no testify, no logging libs, no `View()` returning string,
 no pointer-to-interface, no globals, no silenced errors, no inline comments.
+- Search/MG expansion anti-patterns: `references/anti-patterns.md` §Search / MG expansion

--- a/.agents/skills/golang/references/anti-patterns.md
+++ b/.agents/skills/golang/references/anti-patterns.md
@@ -306,3 +306,61 @@ os.WriteFile(path, data, 0o600)
 // CORRECT — tmp file + rename (already implemented in state.Store.write):
 store.SaveState()   // use the Store methods; don't write files directly
 ```
+
+---
+
+## Search / MG expansion
+
+### ✗ Reconstructing role→subscription relationships from SearchHit fields
+
+```go
+// WRONG — reconstructing by MG ID after the fact:
+mgToMatchedSubs := map[string][]string{}
+for _, h := range hits {
+    if mg := h.ManagementGroup; mg != "" {
+        mgToMatchedSubs[mg] = append(mgToMatchedSubs[mg], h.SubscriptionID)
+    }
+}
+for _, r := range roles {
+    mgID := ManagementGroupIDFromScope(r.Scope)
+    subs, ok := mgToMatchedSubs[mgID] // breaks when physical parent ≠ eligibility MG
+    ...
+}
+```
+
+Why it breaks: `SearchHit.ManagementGroup` is the **physical direct parent MG**.
+When eligibility is granted at an ancestor MG, `ManagementGroupIDFromScope(r.Scope)`
+and `h.ManagementGroup` differ — the lookup misses and blocks are silently dropped.
+
+```go
+// CORRECT — capture at expansion time, look up directly:
+role, ok := subRoleMap[strings.ToLower(h.SubscriptionID)][strings.ToLower(roleName)]
+```
+
+See `patterns.md` (`## Capture relationships at expansion time`) and `mg-search.md`.
+
+### ✗ Calling ListAllSubscriptionsUnderMG in an interactive path
+
+```go
+// WRONG — stalls on enterprise tenants (15s/node × N timed-out nodes):
+case tea.KeyPressMsg:
+    subs, _, _, err := client.ListAllSubscriptionsUnderMG(ctx, mgID)
+    ...
+```
+
+Interactive paths (TUI render, dashboard shortcuts, favorite activation) must
+never call `ListAllSubscriptionsUnderMG`. Pre-resolved `scope` + `schedule_id`
+on the favorite config is the correct contract. See `mg-search.md`.
+
+### ✗ Depending on GetEligibleRoles API return order
+
+```go
+// WRONG — first match is non-deterministic across sessions:
+if len(matches) > 1 {
+    return matches[0] // API order varies; wrong MG may be selected
+}
+```
+
+`GetEligibleRoles` returns roles sorted by `(Scope, RoleName)` (`roles.go`).
+This sort is **load-bearing for `autoAdvance` determinism** — do not remove it.
+When adding selection logic that depends on order, assert the sort is in place.

--- a/.agents/skills/golang/references/azure-pim-api.md
+++ b/.agents/skills/golang/references/azure-pim-api.md
@@ -49,6 +49,10 @@ calling user's eligibilities only.
 - `properties.scope` → stored as `Role.Scope`
 - `properties.roleDefinitionId` → stored as `Role.RoleDefinitionID` — full scope-prefixed path, pass verbatim
 
+> **Load-bearing sort:** `GetEligibleRoles` returns roles sorted by `(Scope, RoleName)`
+> (`internal/azure/roles.go`). This sort is required for `autoAdvance` determinism —
+> do not remove it. Selection logic in `rolelist.go` depends on stable order.
+
 ---
 
 ## 2. Fetch active assignments
@@ -147,6 +151,11 @@ A user with eligibility at a **management group** can activate at a narrower chi
 **Critical rule:** `linkedRoleEligibilityScheduleId` must always be the **full ARM resource
 path** as returned by the `roleEligibilitySchedules` API. Stripping it to a bare GUID causes
 HTTP 400 or HTTP 403 at the child scope.
+
+> **Canonical key:** `linkedRoleEligibilityScheduleId` (`Role.EligibilityScheduleID`) is
+> the globally-unique identifier for an eligibility. When it is known (stored in
+> `Favorite.ScheduleID` or `RecentActivation.ScheduleID`), select the role by exact ID
+> match and skip all name/scope heuristics. `pim search --output toml` always emits it.
 
 ### Why not re-query eligibility at the child scope?
 
@@ -286,3 +295,25 @@ curl -X PUT ".../subscriptions/30cfbf5f-.../providers/Microsoft.Authorization/
 | Bare GUID for `linkedRoleEligibilityScheduleId` | HTTP 400 |
 | Re-query `roleEligibilityScheduleInstances` at child scope | Returns empty — inherited MG eligibilities not visible |
 | Keep full ARM path for `linkedRoleEligibilityScheduleId` (correct) but PUT at RG scope | HTTP 403 (Azure pre-check, not a request body issue) |
+
+---
+
+## 9. Large-tenant timeout & interactive-path rule
+
+`ListAllSubscriptionsUnderMG` walks the MG tree via `eligibleChildResources?$getAllChildren=true`.
+Each node gets `mgNodeTimeoutDefault = 15 s` (`internal/azure/discovery.go`).
+On enterprise tenants with deep hierarchies, individual nodes consistently time out.
+
+**Hard rule: MG expansion is a headless/background-only operation.**
+
+| Path | Allowed? |
+|---|---|
+| `pim search` (headless) | ✓ — user expects latency; warnings go to stderr |
+| TUI render / dashboard | ✗ — stalls UI thread |
+| Favorite 1–9 shortcut | ✗ — stalls for 15s × N timed-out nodes |
+| `--headless` activation | ✓ — blocks shell, user accepts latency |
+
+The safe interactive contract: favorites carry pre-resolved `scope` + `schedule_id`.
+No MG expansion is needed at activation time when these fields are set.
+
+Override the per-node timeout with `PIM_MG_NODE_TIMEOUT` (e.g. `PIM_MG_NODE_TIMEOUT=45s`).

--- a/.agents/skills/golang/references/mg-search.md
+++ b/.agents/skills/golang/references/mg-search.md
@@ -1,0 +1,148 @@
+# pim search — MG Expansion & TOML Output Reference
+
+This document covers the design of `pim search`, the management group expansion
+pipeline, and the `--output toml` guarantees. Read this before extending any
+search, discovery, or TOML-output code path.
+
+## Hard constraints
+
+### MG/subscription ARM paths are flat
+
+ARM scope paths for management groups and subscriptions are structurally
+unrelated strings:
+
+- MG: `/providers/Microsoft.Management/managementGroups/{id}`
+- Subscription: `/subscriptions/{guid}`
+
+`ScopeIsChildOf(child, parent string)` uses `strings.HasPrefix` — it **cannot
+cross the MG/subscription boundary**. A subscription is semantically a child of
+an MG but never a string-path child. Never attempt to infer MG→subscription
+parentage from scope strings alone.
+
+### `$getAllChildren=true` is headless-only
+
+`ListAllSubscriptionsUnderMG` calls `eligibleChildResources?$getAllChildren=true`
+on each MG node. Per-node timeout is `mgNodeTimeoutDefault = 15s`
+(`internal/azure/discovery.go`). On enterprise tenants with deep hierarchies,
+this fans out to dozens of nodes and consistently exceeds 15s per stalled node.
+
+**Never call `ListAllSubscriptionsUnderMG` synchronously in an interactive path**
+(TUI render, dashboard shortcut, favorite activation). It will stall enterprise
+tenants. The safe interactive-path contract is: favorites carry pre-resolved
+`scope` + `schedule_id`; expansion runs only in `pim search` (headless).
+
+Inaccessible MG nodes are skipped with a stderr warning — not fatal. The
+command completes with partial results.
+
+### `EligibilityScheduleID` is the canonical activation key
+
+`Role.EligibilityScheduleID` is the full ARM resource path of the eligibility
+schedule as returned by `GetEligibleRoles`. It is globally unique per
+(principal, role definition, eligibility scope) and is what `ActivateRole` sends
+in `linkedRoleEligibilityScheduleID`. When it is known, select roles by exact ID
+match — never by name/scope heuristics.
+
+## buildSearchHits pipeline
+
+```
+GetEligibleRoles()
+    │
+    ▼
+buildSearchHits()          ← MG expansion happens here
+    │  returns ([]SearchHit, subRoleMap, error)
+    │
+    ├── filterSearchHits()  ← query string filter
+    ├── filterHitsByMG()    ← --mg filter
+    │
+    ├── jsonOut()           ← --output json
+    ├── tomlFromHits()      ← --output toml  (uses subRoleMap)
+    └── tabwriter           ← --output table (default)
+```
+
+### SearchHit shape
+
+```go
+type SearchHit struct {
+    SubscriptionID   string   // resolved subscription GUID
+    DisplayName      string   // subscription display name
+    ManagementGroup  string   // direct physical parent MG ID (may differ from eligibility MG)
+    EligibilityScope string   // first-writer MG ARM path (lossy — one per hit)
+    EligibleRoles    []string // role names only — use subRoleMap for full Role objects
+}
+```
+
+`EligibleRoles` carries names only. The associated `azure.Role` objects (with
+`EligibilityScheduleID` and `Scope`) live in `subRoleMap`.
+
+### subRoleMap contract
+
+`buildSearchHits` returns a `map[string]map[string]azure.Role` alongside
+`[]SearchHit`:
+
+- Outer key: `strings.ToLower(subscriptionID)`
+- Inner key: `strings.ToLower(roleName)`
+- Value: the exact `azure.Role` that granted this role to this subscription,
+  captured **at expansion time** inside the `add()` closure
+
+First-writer-wins when the same (subscription, roleName) pair is reachable via
+multiple eligibilities (e.g. both a sub-direct role and an MG-inherited role).
+
+**This is the canonical way to recover the granting `azure.Role` for any
+(subscription, roleName) pair. Never reconstruct it from `SearchHit` fields
+downstream — see anti-patterns.md.**
+
+## tomlFromHits contract
+
+`tomlFromHits(hits []SearchHit, subRoleMap map[string]map[string]azure.Role, out io.Writer) error`
+
+For each `SearchHit`, iterates `h.EligibleRoles` and looks up the granting
+`azure.Role` via `subRoleMap[subKey][roleName]`. Emits one `[[favorites]]` block
+per (subscription, role) pair.
+
+### What --output toml guarantees
+
+Every emitted block has:
+
+| Field | Value | Source |
+|---|---|---|
+| `scope` | `/subscriptions/<guid>` | activation target (PUT URL) |
+| `eligibility_scope` | MG ARM path | MG-inherited roles only; from `role.Scope` |
+| `schedule_id` | full eligibility ARM path | `role.EligibilityScheduleID` |
+
+Users fill in only `duration`, `justification`, and `key`. Never write
+`schedule_id` or `eligibility_scope` by hand.
+
+`scope` and `schedule_id` are always both present even for sub-direct roles
+where they reference the same subscription — they serve different purposes:
+`scope` is the PUT URL target; `schedule_id` is the request body eligibility
+reference.
+
+### Role object selection precedence (tomlFromHits)
+
+For each (subscription, roleName) pair:
+1. `subRoleMap[subID][roleName]` — direct lookup, no fallback needed
+
+If the lookup misses (role in `EligibleRoles` but absent from `subRoleMap` —
+should not happen in normal operation): skip the block rather than guessing.
+
+## MG expansion internals
+
+`ListAllSubscriptionsUnderMG` does a bounded parallel BFS:
+
+- 8 concurrent workers (`const workers = 8`)
+- 15s per-node timeout (`mgNodeTimeoutDefault`, overridable via `PIM_MG_NODE_TIMEOUT`)
+- Adaptive clamp: `min(mgNodeTimeoutDefault, remaining parent deadline)`
+- Results: `(subs []Subscription, parents map[subID]mgID, warnings []string, err error)`
+- `parents` maps each subscription to its **direct physical parent MG ID** — this
+  may differ from the eligibility MG when eligibility is granted at an ancestor
+
+The `parents` map uses lexically-smallest MG ID per subscription for
+deterministic output on diamond topologies.
+
+## Adding a new --output mode
+
+1. Add a constant to `internal/app/config.go` `OutputFormat`
+2. Add a case in `runSearchWithErr` after the JSON branch, before the table branch
+3. Consume `hits` and `subRoleMap` — both are available at that point
+4. Do not re-expand MGs; do not call `ListAllSubscriptionsUnderMG`
+5. Add a test in `search_test.go` using `searchMock` with `mgSubs` populated

--- a/.agents/skills/golang/references/patterns.md
+++ b/.agents/skills/golang/references/patterns.md
@@ -306,7 +306,15 @@ func ScopeIsChildOf(child, parent string) bool {
 }
 ```
 
-`scopeOverride` in `wizard.go:290` and `autoAdvance` in `rolelist.go:202` both use this contract. When adding new scope-matching logic, call `azure.ScopeMatches` — don't inline the logic again.
+`scopeOverride` in `wizard.go` and `autoAdvance` in `rolelist.go` both use this contract.
+`autoAdvance` resolution order (highest priority first):
+1. Exact `schedule_id` match (`role.EligibilityScheduleID == fav.ScheduleID`) — iterates `m.roles` (full list)
+2. Exact `eligibility_scope` match (`role.Scope == m.eligibilityScope`) — pre-filter before heuristics
+3. Scope child-of narrowing (`ScopeIsChildOf` / `ScopeMatches`) — narrows to `len(narrowed)==1`
+4. Single-MG-candidate trust — only when exactly `len(matches)==1` and all are MG-scoped with a sub GUID filter
+5. Fall through → manual role list (safe default for ambiguous cases)
+
+When adding new scope-matching logic, call `azure.ScopeMatches` — don't inline the logic again.
 
 ---
 
@@ -401,3 +409,67 @@ if err := run(); err != nil {
 ```
 
 Avoids the common anti-pattern of `os.Exit(1)` inside library code or double-printing errors.
+
+---
+
+## Capture relationships at expansion time (subRoleMap)
+
+When flattening a 1→N expansion (e.g. MG → subscriptions), build a side-channel
+index during the walk so downstream functions receive exact objects — not
+reconstructable IDs.
+
+```go
+// In buildSearchHits — the expansion walk:
+subRoleMap := map[string]map[string]azure.Role{}
+
+add := func(role azure.Role, subID, display, mg, eligibilityScope string) {
+    key := strings.ToLower(subID)
+    // ... accumulate SearchHit fields ...
+    if _, ok := subRoleMap[key]; !ok {
+        subRoleMap[key] = map[string]azure.Role{}
+    }
+    rn := strings.ToLower(role.RoleName)
+    if _, ok := subRoleMap[key][rn]; !ok {
+        subRoleMap[key][rn] = role // first-writer-wins
+    }
+}
+// Return alongside hits:
+return hits, subRoleMap, nil
+
+// In tomlFromHits — direct O(1) lookup, no reconstruction:
+role, ok := subRoleMap[strings.ToLower(h.SubscriptionID)][strings.ToLower(roleName)]
+if !ok {
+    continue
+}
+// role.EligibilityScheduleID and role.Scope are exact — no guessing.
+```
+
+**Rule:** never reconstruct the granting `azure.Role` from `SearchHit` string
+fields (ManagementGroup, EligibilityScope) after the fact. Capture it during
+the walk. See `anti-patterns.md` for the wrong approach and `mg-search.md` for
+the full contract.
+
+The cost of getting this wrong: `tomlFromHits` was rewritten six times before
+this design was reached. Every iteration fixed one topology case and broke
+another.
+
+---
+
+## buildSearchHits → tomlFromHits data-flow contract
+
+`buildSearchHits` returns `([]SearchHit, map[string]map[string]azure.Role, error)`.
+Both return values must be passed to any TOML-producing function.
+
+Key-casing rules (both write and read sides must match):
+- Outer key: `strings.ToLower(subscriptionID)`
+- Inner key: `strings.ToLower(roleName)`
+
+`SearchHit.EligibleRoles []string` is authoritative for which roles apply to a
+subscription. `subRoleMap` provides the full `azure.Role` object for each.
+They are complementary — do not use one without the other for TOML output.
+
+`SearchHit.ManagementGroup` is the **physical direct parent MG**, not the
+eligibility MG. These differ in deep hierarchies. Never use `ManagementGroup`
+to reconstruct which `azure.Role` granted a given roleName — use `subRoleMap`.
+
+See `mg-search.md` for the full pipeline diagram.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Terminal-based Azure Privileged Identity Management role activation. Bubble Tea 
 internal/app/        CLI flag parsing, app composition, ctx setup
 internal/azure/      PIM REST client (client/roles/activation/discovery), errors, scopes, duration
 internal/state/      TOML config + state with mutex-guarded Store
-internal/headless/   non-TUI execution path for --headless
+  internal/headless/   non-TUI execution path (run.go) + pim search subcommand (search.go)
 internal/completion/ shell completion script generators (bash/zsh/fish)
 internal/tui/        Bubble Tea screens
   activate/          4-step wizard
@@ -95,6 +95,9 @@ irm https://raw.githubusercontent.com/jeircul/pim/main/scripts/install.ps1 | iex
 - `roleAssignmentSchedules` GET at RG scope returns 500 when the caller lacks read access. Treated as "not active".
 - `GetEligibleRoles` and `GetActiveAssignments` paginate via `nextLink`.
 - `PendingRoleAssignmentRequest` (HTTP 400) is treated as success at all scopes — the role is already activating.
+- **MG/subscription ARM paths are flat (hard constraint).** `/providers/Microsoft.Management/managementGroups/{id}` and `/subscriptions/{guid}` are structurally unrelated strings — `ScopeIsChildOf` cannot cross this boundary. A subscription is semantically a child of an MG but never a string-path child. Never infer MG→subscription parentage from scope strings alone.
+- **`$getAllChildren=true` is headless-only.** Per-node timeout is 15 s (`mgNodeTimeoutDefault` in `discovery.go`). On enterprise tenants this consistently stalls. Never call `ListAllSubscriptionsUnderMG` synchronously in an interactive path (TUI render, dashboard shortcut, favorite activation). Favorites carry pre-resolved `scope` + `schedule_id` instead.
+- **`EligibilityScheduleID` is the canonical activation key.** It is globally unique per (principal, role definition, eligibility scope) and is what `ActivateRole` sends in `linkedRoleEligibilityScheduleID`. When known, select roles by exact ID match — never by name/scope heuristics. `pim search --output toml` always emits it; users should never hand-write it.
 
 Full API reference: `.agents/skills/golang/references/azure-pim-api.md`.
 
@@ -111,11 +114,37 @@ Full API reference: `.agents/skills/golang/references/azure-pim-api.md`.
 - Dashboard 1–9 shortcut: if `Complete()` → `startWizard` with `AutoSubmit=true` and `favoritePending=true`; activation result shown as dashboard notice, TUI stays open. If not `Complete()` → error notice, no activation.
 - `favoritePending` on `AppModel` distinguishes favorite-triggered activations (return to dashboard) from manual wizard activations (quit with summary).
 - Favorites screen `ActivateMsg` always opens the wizard (incomplete favorites stop at the missing step).
-- `autoAdvance` in `rolelist.go` uses `scopeFilter` as a tiebreaker when multiple roles share the same name. When all matches are MG-scoped and the filter is a bare subscription GUID, the first match is trusted (Azure rejects wrong-scope activations with 400/403). `scopeOverride` pins the subscription as `targetScope` when exactly one MG-scoped role is selected.
+- **Role selection precedence in `autoAdvance`** (`rolelist.go`):
+  1. Exact `schedule_id` match — iterates full role list, bypasses all heuristics
+  2. Exact `eligibility_scope` match — pre-filters by MG ARM path before narrowing
+  3. Scope child-of narrowing (`ScopeIsChildOf` / `ScopeMatches`) — narrows to single match
+  4. Single-MG-candidate trust — only when exactly one MG-scoped match and a bare sub GUID filter
+  5. Fall through → manual role list (safe default for ambiguous cases)
 - `RecentActivation.EligibilityScope` stores the ARM eligibility path at activation time. Re-activation from the Recent screen prefers this over `Scope` so the wizard matches the original role precisely.
 - `pim search --output toml` generates paste-ready `[[favorites]]` blocks with `scope`, `eligibility_scope` (MG-inherited roles only), and `schedule_id` pre-filled. Users fill in `duration`, `justification`, and `key` only. Never write `schedule_id` or `eligibility_scope` by hand.
 - `Favorite.ScheduleID` is the `EligibilityScheduleID` from the Azure PIM API — the globally-unique key used by `ActivateRole` in `linkedRoleEligibilityScheduleID`. When set, `autoAdvance` selects the matching role by exact ID, bypassing all name/scope heuristics. Falls through to `eligibility_scope` + heuristics when empty (hand-written or pre-`schedule_id` favorites).
 - `scope` and `schedule_id` are always both required even when they reference the same subscription: `scope` is the PUT URL target; `schedule_id` identifies the eligibility schedule in the request body.
+
+## pim search
+
+`pim search [query] [--mg filter] [--output table|json|toml]` discovers eligible
+subscriptions across all management groups.
+
+**Pipeline:** `GetEligibleRoles` → `buildSearchHits` (MG expansion + `subRoleMap`) →
+filter → output formatter. `buildSearchHits` returns `([]SearchHit, subRoleMap, error)`;
+the `subRoleMap` carries the exact `azure.Role` that granted each role to each
+subscription, captured at expansion time. `tomlFromHits` consumes both.
+
+**`--output toml` contract:** emits one `[[favorites]]` block per (subscription, role)
+with `scope` (activation target), `eligibility_scope` (MG-inherited only), and
+`schedule_id` (`EligibilityScheduleID`) pre-filled. Users fill in `duration`,
+`justification`, and `key` only. Never write `schedule_id` or `eligibility_scope`
+by hand.
+
+**MG timeout behaviour:** inaccessible MG nodes are skipped as stderr warnings —
+not fatal. Results are partial but correct for the nodes that responded.
+
+See `.agents/skills/golang/references/mg-search.md` for the full design reference.
 
 ## Recent behaviour
 
@@ -151,6 +180,7 @@ Full API reference: `.agents/skills/golang/references/azure-pim-api.md`.
 1. Does any value in this text originate from pasted terminal output or a live session?
 2. Does it match `[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}` and is it **not** an all-zero/repeated-nibble sentinel?
 3. Is it a proper noun that is not an Azure built-in role or a well-known public Azure service name?
+4. Does this text include subscription display names, management group names, or role names from `pim search` terminal output? Those are high-risk — they originate from a live environment and must be replaced with the placeholder vocabulary above before writing.
 
 → Any "yes" → replace with the placeholder above **before** writing.
 


### PR DESCRIPTION
Updates AGENTS.md, skill references, and bubbletea-wizard skill with lessons from the v0.7.0 development session. No production code changes — docs/AI config only.

- New `mg-search.md` reference doc (pim search design, subRoleMap pattern, tomlFromHits contract)
- Three hard constraints added to AGENTS.md API quirks (MG/sub flat paths, headless-only expansion, EligibilityScheduleID primacy)
- autoAdvance 5-tier precedence documented in AGENTS.md + patterns.md
- Three MG expansion anti-patterns added
- azure-pim-api.md: §9 large-tenant timeout rule + load-bearing sort note