### PR TITLE
fix: clarify duration error message and fix AGENTS.md layout indentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Terminal-based Azure Privileged Identity Management role activation. Bubble Tea 
 internal/app/        CLI flag parsing, app composition, ctx setup
 internal/azure/      PIM REST client (client/roles/activation/discovery), errors, scopes, duration
 internal/state/      TOML config + state with mutex-guarded Store
-  internal/headless/   non-TUI execution path (run.go) + pim search subcommand (search.go)
+internal/headless/   non-TUI execution path (run.go) + pim search subcommand (search.go)
 internal/completion/ shell completion script generators (bash/zsh/fish)
 internal/tui/        Bubble Tea screens
   activate/          4-step wizard

--- a/internal/azure/duration.go
+++ b/internal/azure/duration.go
@@ -85,5 +85,5 @@ func ParseDurationMinutes(s string) (int, error) {
 		}
 	}
 
-	return 0, fmt.Errorf("unrecognised duration %q; use 1h, 30m, 1h30m, or 1.5h", s)
+	return 0, fmt.Errorf("unrecognised duration %q; expected a duration like 30m, 1h, or 1h30m", s)
 }

--- a/internal/azure/duration.go
+++ b/internal/azure/duration.go
@@ -85,5 +85,5 @@ func ParseDurationMinutes(s string) (int, error) {
 		}
 	}
 
-	return 0, fmt.Errorf("unrecognised duration %q; expected a duration like 30m, 1h, or 1h30m", s)
+	return 0, fmt.Errorf("unrecognised duration %q; expected a duration like 30m, 1h, 1h30m, or 1.5h", s)
 }


### PR DESCRIPTION
Fixes two nitpicks caught in review:

- **`internal/azure/duration.go`**: error message now reads as a format hint (`expected a duration like 30m, 1h, 1h30m, or 1.5h`) rather than an exhaustive list. Includes the decimal-hour form (`1.5h`) as requested by reviewer.
- **`AGENTS.md`**: `internal/headless/` was incorrectly indented as a child of `internal/state/` in the layout tree — fixed to top-level sibling.

The additional docs files visible in the diff are from `chore/ai-config-docs` (PR #57, already merged) which this branch was rebased onto before that merge was reflected locally. They contain no new changes relative to `main`.

Closes #56