### PR TITLE
fix: headless --scope accepts MG display name in full ARM path

### DIFF
--- a/internal/headless/run.go
+++ b/internal/headless/run.go
@@ -227,6 +227,24 @@ func filterRoles(ctx context.Context, client ClientAPI, roles []azure.Role, role
 				armMatches[i] = struct{}{}
 			}
 		}
+		// When the user supplies a full MG ARM path whose ID is a display name
+		// (e.g. /providers/.../managementGroups/Omnia-Classic-DEV) but the actual
+		// ARM ID in GetEligibleRoles is a GUID, the path match above fails. Fall
+		// back to exact display-name match against the MG ID segment.
+		if len(armMatches) == 0 {
+			mgID := azure.ManagementGroupIDFromScope(expanded)
+			if mgID != "" {
+				for _, i := range roleIdx {
+					if !azure.IsManagementGroupScope(roles[i].Scope) {
+						continue
+					}
+					if strings.EqualFold(mgID, azure.ManagementGroupIDFromScope(roles[i].Scope)) ||
+						strings.EqualFold(mgID, scopeDisplays[i]) {
+						armMatches[i] = struct{}{}
+					}
+				}
+			}
+		}
 		if len(armMatches) > 0 {
 			for i := range armMatches {
 				add(roleTarget{role: roles[i], scope: expanded})


### PR DESCRIPTION
Fixes the case where `pim activate --scope /providers/.../managementGroups/Omnia-Classic-DEV` returns 'no eligible roles' because the actual MG ID in the PIM API is a GUID, not the display name.

Adds a fallback in `filterRoles` that matches the MG ID segment case-insensitively against both the ARM ID and the ScopeDisplay when the path match fails.